### PR TITLE
Report more precise source locations #78

### DIFF
--- a/CheckedExceptions.Tests/AnazylerConfigTest.cs
+++ b/CheckedExceptions.Tests/AnazylerConfigTest.cs
@@ -43,7 +43,7 @@ public partial class AnaylzerConfigTest
             """;
 
         var expected = Verifier.Informational("IOException")
-            .WithSpan(7, 9, 7, 35);
+            .WithSpan(7, 17, 7, 35);
 
         await Verifier.VerifyAnalyzerAsync2(test, expected);
     }
@@ -71,7 +71,7 @@ public partial class AnaylzerConfigTest
             """;
 
         var expected2 = Verifier.Informational("IOException")
-            .WithSpan(9, 13, 9, 39);
+            .WithSpan(9, 21, 9, 39);
 
         await Verifier.VerifyAnalyzerAsync2(test, expected2);
     }

--- a/CheckedExceptions.Tests/AwaitTest.cs
+++ b/CheckedExceptions.Tests/AwaitTest.cs
@@ -90,7 +90,7 @@ public partial class AwaitTest
             """;
 
         var expected = Verifier.MightBeThrown("InvalidOperationException")
-            .WithSpan(14, 15, 14, 35);
+            .WithSpan(14, 20, 14, 35);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }

--- a/CheckedExceptions.Tests/BugFixes/Bugfix19_CatchBlockSilencesExceptionInCatchClauses.cs
+++ b/CheckedExceptions.Tests/BugFixes/Bugfix19_CatchBlockSilencesExceptionInCatchClauses.cs
@@ -35,10 +35,10 @@ public partial class Bugfix19_CatchBlockSilencesExceptionInCatchClauses
             """;
 
         var expected1 = Verifier.MightBeThrown("IOException")
-            .WithSpan(10, 13, 10, 33); // Position of Console.Write("Foo");
+            .WithSpan(10, 21, 10, 33); // Position of Console.Write("Foo");
 
         var expected2 = Verifier.MightBeThrown("IOException")
-            .WithSpan(14, 13, 14, 41); // Position of Console.WriteLine(e.Message);
+            .WithSpan(14, 21, 14, 41); // Position of Console.WriteLine(e.Message);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);
     }
@@ -72,7 +72,7 @@ public partial class Bugfix19_CatchBlockSilencesExceptionInCatchClauses
             """;
 
         var expected = Verifier.MightBeThrown("IOException")
-            .WithSpan(15, 13, 15, 41); // Position of Console.WriteLine(e.Message);
+            .WithSpan(15, 21, 15, 41); // Position of Console.WriteLine(e.Message);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);
     }

--- a/CheckedExceptions.Tests/DictionaryTest.cs
+++ b/CheckedExceptions.Tests/DictionaryTest.cs
@@ -29,7 +29,7 @@ public partial class DictionaryTest
             """;
 
         var expected = Verifier.MightBeThrown("ArgumentException")
-            .WithSpan(10, 9, 10, 28);
+            .WithSpan(10, 14, 10, 28);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }

--- a/CheckedExceptions.Tests/ExtensionMethods.cs
+++ b/CheckedExceptions.Tests/ExtensionMethods.cs
@@ -27,10 +27,10 @@ public partial class ExtensionMethods
         """;
 
         var expected1 = Verifier.MightBeThrown("ArgumentNullException")
-           .WithSpan(11, 17, 11, 30);
+           .WithSpan(11, 23, 11, 30);
 
         var expected2 = Verifier.MightBeThrown("InvalidOperationException")
-           .WithSpan(11, 17, 11, 30);
+           .WithSpan(11, 23, 11, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
     }
@@ -57,7 +57,7 @@ public partial class ExtensionMethods
         """;
 
         var expected = Verifier.MightBeThrown("InvalidOperationException")
-           .WithSpan(12, 17, 12, 30);
+           .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }
@@ -84,7 +84,7 @@ public partial class ExtensionMethods
         """;
 
         var expected = Verifier.MightBeThrown("InvalidOperationException")
-           .WithSpan(12, 17, 12, 30);
+           .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }
@@ -111,7 +111,7 @@ public partial class ExtensionMethods
         """;
 
         var expected = Verifier.MightBeThrown("InvalidOperationException")
-           .WithSpan(12, 17, 12, 30);
+           .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }

--- a/CheckedExceptions.Tests/MemberAccessAndIdentifierNameTest.cs
+++ b/CheckedExceptions.Tests/MemberAccessAndIdentifierNameTest.cs
@@ -31,7 +31,7 @@ public partial class MemberAccessAndIdentifierNameTest
             """;
 
         var expected = Verifier.MightBeThrown("ArgumentNullException")
-            .WithSpan(15, 9, 15, 19);
+            .WithSpan(15, 14, 15, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
     }
@@ -89,7 +89,7 @@ public partial class MemberAccessAndIdentifierNameTest
             """;
 
         var expected = Verifier.MightBeThrown("ArgumentNullException")
-            .WithSpan(15, 9, 15, 19);
+            .WithSpan(15, 14, 15, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);
     }

--- a/CheckedExceptions.Tests/XmlDocTest.cs
+++ b/CheckedExceptions.Tests/XmlDocTest.cs
@@ -57,13 +57,13 @@ public partial class XmlDocTest
             """;
 
         var expected1 = Verifier.MightBeThrown("ArgumentNullException")
-            .WithSpan(7, 9, 7, 24);
+            .WithSpan(7, 13, 7, 24);
 
         var expected2 = Verifier.MightBeThrown("FormatException")
-            .WithSpan(7, 9, 7, 24);
+            .WithSpan(7, 13, 7, 24);
 
         var expected3 = Verifier.MightBeThrown("OverflowException")
-            .WithSpan(7, 9, 7, 24);
+            .WithSpan(7, 13, 7, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2, expected3);
     }
@@ -87,10 +87,10 @@ public partial class XmlDocTest
             """;
 
         var expected2 = Verifier.MightBeThrown("FormatException")
-            .WithSpan(8, 9, 8, 24);
+            .WithSpan(8, 13, 8, 24);
 
         var expected3 = Verifier.MightBeThrown("OverflowException")
-            .WithSpan(8, 9, 8, 24);
+            .WithSpan(8, 13, 8, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected2, expected3]);
     }
@@ -139,7 +139,7 @@ public partial class XmlDocTest
             """;
 
         var expected = Verifier.MightBeThrown("ArgumentOutOfRangeException")
-            .WithSpan(11, 9, 11, 29);
+            .WithSpan(11, 23, 11, 29);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);
     }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Sundstrom.CheckedExceptions;
 
@@ -124,11 +125,20 @@ partial class CheckedExceptionsAnalyzer
         return node.Ancestors().OfType<CatchClauseSyntax>().FirstOrDefault();
     }
 
-    private static SyntaxNode GetSignificantNode(SyntaxNode expression)
+    private static Location GetSignificantLocation(SyntaxNode expression)
+    {
+        if (expression is InvocationExpressionSyntax)
+            return GetSignificantInvocationLocation(expression);
+
+        var node = GetSignificantNodeCore(expression);
+        return node.GetLocation();
+    }
+
+    private static SyntaxNode GetSignificantNodeCore(SyntaxNode expression)
     {
         if (expression is InvocationExpressionSyntax ie)
         {
-            return GetSignificantNode(ie.Expression);
+            return GetSignificantNodeCore(ie.Expression);
         }
 
         if (expression is MemberAccessExpressionSyntax mae)
@@ -137,5 +147,23 @@ partial class CheckedExceptionsAnalyzer
         }
 
         return expression;
+    }
+
+    private static Location GetSignificantInvocationLocation(SyntaxNode expression)
+    {
+        if (expression is InvocationExpressionSyntax invocation)
+        {
+            // Get the name part (e.g., bar in foo.bar(s))
+            var nameNode = GetSignificantNodeCore(invocation.Expression);
+
+            // Compute the span from name start to the full invocation end
+            var start = nameNode.SpanStart;
+            var end = invocation.Span.End;
+
+            var span = TextSpan.FromBounds(start, end);
+            return Location.Create(invocation.SyntaxTree, span);
+        }
+
+        return expression.GetLocation();
     }
 }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
@@ -124,11 +124,11 @@ partial class CheckedExceptionsAnalyzer
         return node.Ancestors().OfType<CatchClauseSyntax>().FirstOrDefault();
     }
 
-    private static SyntaxNode GetExpression(SyntaxNode expression)
+    private static SyntaxNode GetSignificantNode(SyntaxNode expression)
     {
         if (expression is InvocationExpressionSyntax ie)
         {
-            return GetExpression(ie.Expression);
+            return GetSignificantNode(ie.Expression);
         }
 
         if (expression is MemberAccessExpressionSyntax mae)

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Shared.cs
@@ -123,4 +123,19 @@ partial class CheckedExceptionsAnalyzer
     {
         return node.Ancestors().OfType<CatchClauseSyntax>().FirstOrDefault();
     }
+
+    private static SyntaxNode GetExpression(SyntaxNode expression)
+    {
+        if (expression is InvocationExpressionSyntax ie)
+        {
+            return GetExpression(ie.Expression);
+        }
+
+        if (expression is MemberAccessExpressionSyntax mae)
+        {
+            return mae.Name;
+        }
+
+        return expression;
+    }
 }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -1195,7 +1195,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
             if (ShouldIgnore(node, mode))
             {
                 // Report as THROW002 (Info level)
-                var diagnostic = Diagnostic.Create(RuleIgnoredException, GetExpression(node).GetLocation(), exceptionType.Name);
+                var diagnostic = Diagnostic.Create(RuleIgnoredException, GetSignificantNode(node).GetLocation(), exceptionType.Name);
                 context.ReportDiagnostic(diagnostic);
                 return;
             }
@@ -1204,7 +1204,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         // Check for general exceptions
         if (IsGeneralException(exceptionType))
         {
-            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, GetExpression(node).GetLocation()));
+            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, GetSignificantNode(node).GetLocation()));
         }
 
         // Check if the exception is declared via [Throws]
@@ -1223,7 +1223,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
             var verb = isThrowingConstruct ? THROW001Verbs.Is : THROW001Verbs.MightBe;
 
-            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetExpression(node).GetLocation(), properties, exceptionType.Name, verb);
+            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetSignificantNode(node).GetLocation(), properties, exceptionType.Name, verb);
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -351,7 +351,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
                 if (ShouldIgnore(throwStatement, mode))
                 {
                     // Report as THROW002 (Info level)
-                    var diagnostic = Diagnostic.Create(RuleIgnoredException, throwStatement.GetLocation(), exceptionType.Name);
+                    var diagnostic = Diagnostic.Create(RuleIgnoredException, GetSignificantLocation(throwStatement), exceptionType.Name);
                     context.ReportDiagnostic(diagnostic);
                     continue;
                 }
@@ -368,7 +368,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
                 // Report diagnostic for unhandled exception
                 var diagnostic = Diagnostic.Create(
                     RuleUnhandledException,
-                    throwStatement.GetLocation(),
+                    GetSignificantLocation(throwStatement),
                     exceptionType.Name,
                     THROW001Verbs.MightBe);
 
@@ -1195,7 +1195,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
             if (ShouldIgnore(node, mode))
             {
                 // Report as THROW002 (Info level)
-                var diagnostic = Diagnostic.Create(RuleIgnoredException, GetSignificantNode(node).GetLocation(), exceptionType.Name);
+                var diagnostic = Diagnostic.Create(RuleIgnoredException, GetSignificantLocation(node), exceptionType.Name);
                 context.ReportDiagnostic(diagnostic);
                 return;
             }
@@ -1204,7 +1204,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         // Check for general exceptions
         if (IsGeneralException(exceptionType))
         {
-            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, GetSignificantNode(node).GetLocation()));
+            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, GetSignificantLocation(node)));
         }
 
         // Check if the exception is declared via [Throws]
@@ -1223,7 +1223,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
             var verb = isThrowingConstruct ? THROW001Verbs.Is : THROW001Verbs.MightBe;
 
-            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetSignificantNode(node).GetLocation(), properties, exceptionType.Name, verb);
+            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetSignificantLocation(node), properties, exceptionType.Name, verb);
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -1195,7 +1195,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
             if (ShouldIgnore(node, mode))
             {
                 // Report as THROW002 (Info level)
-                var diagnostic = Diagnostic.Create(RuleIgnoredException, node.GetLocation(), exceptionType.Name);
+                var diagnostic = Diagnostic.Create(RuleIgnoredException, GetExpression(node).GetLocation(), exceptionType.Name);
                 context.ReportDiagnostic(diagnostic);
                 return;
             }
@@ -1204,7 +1204,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         // Check for general exceptions
         if (IsGeneralException(exceptionType))
         {
-            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, node.GetLocation()));
+            context.ReportDiagnostic(Diagnostic.Create(RuleGeneralThrow, GetExpression(node).GetLocation()));
         }
 
         // Check if the exception is declared via [Throws]
@@ -1223,7 +1223,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
             var verb = isThrowingConstruct ? THROW001Verbs.Is : THROW001Verbs.MightBe;
 
-            var diagnostic = Diagnostic.Create(RuleUnhandledException, node.GetLocation(), properties, exceptionType.Name, verb);
+            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetExpression(node).GetLocation(), properties, exceptionType.Name, verb);
             context.ReportDiagnostic(diagnostic);
         }
     }


### PR DESCRIPTION
This is helpful when chaining methods or accessing members.

Result:

<img width="532" alt="Screenshot 2025-06-28 at 14 13 33" src="https://github.com/user-attachments/assets/efb685c1-1b75-47e2-8adb-b250eab61241" />

Don't forget to fix tests. Since source location has changed for diagnostics.