### PR TITLE
Change diagnostic messages #74

### DIFF
--- a/CheckedExceptions.Package/docs/README.md
+++ b/CheckedExceptions.Package/docs/README.md
@@ -28,7 +28,7 @@ public class Sample
 {
     public void Execute()
     {
-        // ⚠️ THROW001: Unhandled exception
+        // ⚠️ THROW001: Unhandled exception type 'InvalidOperationException'
         Perform();
     }
 

--- a/CheckedExceptions.Tests/AwaitTest.cs
+++ b/CheckedExceptions.Tests/AwaitTest.cs
@@ -29,7 +29,7 @@ public partial class AwaitTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(14, 15, 14, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -89,7 +89,7 @@ public partial class AwaitTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(14, 20, 14, 35);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/BugFixes/Bugfix19_CatchBlockSilencesExceptionInCatchClauses.cs
+++ b/CheckedExceptions.Tests/BugFixes/Bugfix19_CatchBlockSilencesExceptionInCatchClauses.cs
@@ -34,10 +34,10 @@ public partial class Bugfix19_CatchBlockSilencesExceptionInCatchClauses
             }
             """;
 
-        var expected1 = Verifier.MightBeThrown("IOException")
+        var expected1 = Verifier.UnhandledException("IOException")
             .WithSpan(10, 21, 10, 33); // Position of Console.Write("Foo");
 
-        var expected2 = Verifier.MightBeThrown("IOException")
+        var expected2 = Verifier.UnhandledException("IOException")
             .WithSpan(14, 21, 14, 41); // Position of Console.WriteLine(e.Message);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);
@@ -71,7 +71,7 @@ public partial class Bugfix19_CatchBlockSilencesExceptionInCatchClauses
             }
             """;
 
-        var expected = Verifier.MightBeThrown("IOException")
+        var expected = Verifier.UnhandledException("IOException")
             .WithSpan(15, 21, 15, 41); // Position of Console.WriteLine(e.Message);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);

--- a/CheckedExceptions.Tests/BugFixes/Bugfix39_TryCatchBugs.cs
+++ b/CheckedExceptions.Tests/BugFixes/Bugfix39_TryCatchBugs.cs
@@ -34,7 +34,7 @@ public partial class Bugfix39_TryCatchBugs
         }
         """;
 
-        var expected = Verifier.IsThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
             .WithSpan(19, 13, 19, 43);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -68,7 +68,7 @@ public partial class Bugfix39_TryCatchBugs
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(19, 13, 19, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -103,7 +103,7 @@ public partial class Bugfix39_TryCatchBugs
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(20, 13, 20, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -138,7 +138,7 @@ public partial class Bugfix39_TryCatchBugs
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(20, 13, 20, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/BugFixes/Bugfix50_LambdaScopeBug.cs
+++ b/CheckedExceptions.Tests/BugFixes/Bugfix50_LambdaScopeBug.cs
@@ -26,7 +26,7 @@ public partial class Bugfix50_LambdaScopeBug
         }
         """;
 
-        var expected = Verifier.IsThrown("UnauthorizedAccessException")
+        var expected = Verifier.UnhandledException("UnauthorizedAccessException")
             .WithSpan(9, 13, 9, 94);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -75,7 +75,7 @@ public partial class Bugfix50_LambdaScopeBug
         }
         """;
 
-        var expected = Verifier.IsThrown("UnauthorizedAccessException")
+        var expected = Verifier.UnhandledException("UnauthorizedAccessException")
             .WithSpan(10, 13, 10, 94);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/BugFixes/Bugfix65_TryCatchAroundLambda.cs
+++ b/CheckedExceptions.Tests/BugFixes/Bugfix65_TryCatchAroundLambda.cs
@@ -24,7 +24,7 @@ public partial class Bugfix65_TryCatchAroundLambda
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(8, 13, 8, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -55,7 +55,7 @@ public partial class Bugfix65_TryCatchAroundLambda
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(10, 17, 10, 55);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -80,7 +80,7 @@ public partial class Bugfix65_TryCatchAroundLambda
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 13, 9, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -112,7 +112,7 @@ public partial class Bugfix65_TryCatchAroundLambda
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(11, 17, 11, 55);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
+++ b/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
@@ -16,13 +16,9 @@ public static class CSharpAnalyzerVerifier<TAnalyzer, TVerifier>
     public static DiagnosticResult Diagnostic(string diagnosticId)
         => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic(diagnosticId);
 
-    public static DiagnosticResult IsThrown(string exceptionType)
+    public static DiagnosticResult UnhandledException(string exceptionType)
         => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW001")
-        .WithArguments(exceptionType, THROW001Verbs.Is);
-
-    public static DiagnosticResult MightBeThrown(string exceptionType)
-        => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW001")
-        .WithArguments(exceptionType, THROW001Verbs.MightBe);
+        .WithArguments(exceptionType);
 
     public static DiagnosticResult Informational(string exceptionType)
         => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW002")

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.CheckedExceptionsAnalyzer.Inheritance.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.CheckedExceptionsAnalyzer.Inheritance.cs
@@ -60,10 +60,10 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.MissingThrowsOnBaseMember("IOException", "BaseService.DoWork")
+        var expected = Verifier.MissingThrowsOnBaseMember("IOException", "BaseService.DoWork()")
             .WithSpan(14, 26, 14, 32);
 
-        var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "BaseService.DoWork")
+        var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "BaseService.DoWork()")
             .WithSpan(14, 26, 14, 32);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -94,10 +94,10 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.MissingThrowsOnBaseMember("SocketException", "IOperation.Execute")
+        var expected = Verifier.MissingThrowsOnBaseMember("SocketException", "IOperation.Execute()")
             .WithSpan(15, 17, 15, 24);
 
-        var expected2 = Verifier.MissingThrowsFromBaseMember("IOException", "IOperation.Execute")
+        var expected2 = Verifier.MissingThrowsFromBaseMember("IOException", "IOperation.Execute()")
             .WithSpan(15, 17, 15, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -130,10 +130,10 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.MissingThrowsOnBaseMember("IOException", "Base.get_Value")
+        var expected = Verifier.MissingThrowsOnBaseMember("IOException", "Base.get_Value()")
             .WithSpan(19, 9, 19, 12);
 
-        var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "Base.get_Value")
+        var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "Base.get_Value()")
             .WithSpan(19, 9, 19, 12);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -167,10 +167,10 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.MissingThrowsOnBaseMember("UnauthorizedAccessException", "Base.add_Something")
+        var expected = Verifier.MissingThrowsOnBaseMember("UnauthorizedAccessException", "Base.add_Something(EventHandler)")
             .WithSpan(19, 9, 19, 12);
 
-        var expected2 = Verifier.MissingThrowsFromBaseMember("NotSupportedException", "Base.add_Something")
+        var expected2 = Verifier.MissingThrowsFromBaseMember("NotSupportedException", "Base.add_Something(EventHandler)")
             .WithSpan(19, 9, 19, 12);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Constructors.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Constructors.cs
@@ -36,10 +36,10 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(16, 30, 16, 50); // new ThrowingObject()
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(21, 30, 21, 35); // new()
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.General.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.General.cs
@@ -27,7 +27,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 9, 7, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -123,10 +123,10 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected1 = Verifier.IsThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 9, 7, 47);
 
-        var expected2 = Verifier.IsThrown("ArgumentException")
+        var expected2 = Verifier.UnhandledException("ArgumentException")
             .WithSpan(12, 9, 12, 39);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.GeneralThrows.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.GeneralThrows.cs
@@ -96,7 +96,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.MightBeThrown("Exception")
+        var expected = Verifier.UnhandledException("Exception")
             .WithSpan(8, 9, 8, 17);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -123,7 +123,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.MightBeThrown("Exception")
+        var expected = Verifier.UnhandledException("Exception")
             .WithSpan(13, 9, 13, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Members.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Members.cs
@@ -25,7 +25,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 13, 9, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -51,7 +51,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(11, 13, 11, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -79,10 +79,10 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected1 = Verifier.IsThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 13, 9, 51);
 
-        var expected2 = Verifier.IsThrown("ArgumentException")
+        var expected2 = Verifier.UnhandledException("ArgumentException")
             .WithSpan(13, 13, 13, 43);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
@@ -108,7 +108,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 13, 9, 51);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -130,7 +130,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 31, 7, 68);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -152,7 +152,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 33, 7, 71);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -176,7 +176,7 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 30, 9, 67);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -197,7 +197,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 9, 7, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -218,7 +218,7 @@ partial class CheckedExceptionsAnalyzerTests
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 9, 7, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.cs
@@ -23,7 +23,7 @@ public partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(7, 9, 7, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -45,7 +45,7 @@ public partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected1 = Verifier.IsThrown("Exception")
+        var expected1 = Verifier.UnhandledException("Exception")
             .WithSpan(7, 9, 7, 31);
 
         var expected2 = Verifier.AvoidThrowingTypeException()
@@ -223,10 +223,10 @@ public partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected1 = Verifier.IsThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 13, 9, 51);
 
-        var expected2 = Verifier.IsThrown("ArgumentNullException")
+        var expected2 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(16, 9, 16, 43);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
@@ -261,7 +261,7 @@ public partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(11, 17, 11, 55);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -284,7 +284,7 @@ public partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.IsThrown("CustomException")
+        var expected = Verifier.UnhandledException("CustomException")
             .WithSpan(9, 9, 9, 37);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/CodeFixes/AddThrowsAttributeCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/AddThrowsAttributeCodeFixProviderTests.cs
@@ -45,7 +45,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("Exception")
+        var expectedDiagnostic = Verifier.UnhandledException("Exception")
             .WithSpan(10, 13, 10, 35);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
@@ -87,7 +87,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("InvalidOperationException")
+        var expectedDiagnostic = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(10, 13, 10, 51);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
@@ -164,7 +164,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("ArgumentNullException")
+        var expectedDiagnostic = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(13, 17, 13, 51);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode, expectedIncrementalIterations: 2);
@@ -216,7 +216,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("InvalidOperationException")
+        var expectedDiagnostic = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(12, 17, 12, 55);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode, expectedIncrementalIterations: 2);
@@ -276,7 +276,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("Exception")
+        var expectedDiagnostic = Verifier.UnhandledException("Exception")
             .WithSpan(14, 17, 14, 39);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
@@ -342,10 +342,10 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic1 = Verifier.IsThrown("InvalidOperationException")
+        var expectedDiagnostic1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(14, 17, 14, 55);
 
-        var expectedDiagnostic2 = Verifier.IsThrown("ArgumentNullException")
+        var expectedDiagnostic2 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(17, 17, 17, 51);
 
         await Verifier.VerifyCodeFixAsync(testCode, [expectedDiagnostic1, expectedDiagnostic2], fixedCode, 2);

--- a/CheckedExceptions.Tests/CodeFixes/AddTryCatchBlockCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/AddTryCatchBlockCodeFixProviderTests.cs
@@ -50,7 +50,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.IsThrown("Exception")
+        var expectedDiagnostic = Verifier.UnhandledException("Exception")
             .WithSpan(10, 13, 10, 35);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
@@ -109,7 +109,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.MightBeThrown("InvalidOperationException")
+        var expectedDiagnostic = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(10, 13, 10, 26);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
@@ -170,7 +170,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic = Verifier.MightBeThrown("InvalidOperationException")
+        var expectedDiagnostic = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(10, 21, 10, 34);
 
         await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode, 1);
@@ -243,7 +243,7 @@ namespace TestNamespace
 }
 """;
 
-        var expectedDiagnostic1 = Verifier.MightBeThrown("InvalidOperationException")
+        var expectedDiagnostic1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(16, 17, 16, 30);
 
         await Verifier.VerifyCodeFixAsync(testCode, [expectedDiagnostic1], fixedCode, 1);

--- a/CheckedExceptions.Tests/CodeFixes/CSharpCodeFixVerifier.cs
+++ b/CheckedExceptions.Tests/CodeFixes/CSharpCodeFixVerifier.cs
@@ -20,14 +20,9 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix, TVerifier>
     public static DiagnosticResult Diagnostic(string diagnosticId)
         => CodeFixVerifier<TAnalyzer, TCodeFix, CodeFixTest, TVerifier>.Diagnostic(diagnosticId);
 
-    public static DiagnosticResult IsThrown(string exceptionType)
+    public static DiagnosticResult UnhandledException(string exceptionType)
         => CodeFixVerifier<TAnalyzer, TCodeFix, CodeFixTest, TVerifier>.Diagnostic("THROW001")
-        .WithArguments(exceptionType, THROW001Verbs.Is);
-
-    public static DiagnosticResult MightBeThrown(string exceptionType)
-        => CodeFixVerifier<TAnalyzer, TCodeFix, CodeFixTest, TVerifier>.Diagnostic("THROW001")
-        .WithArguments(exceptionType, THROW001Verbs.MightBe);
-
+        .WithArguments(exceptionType);
 
     public static Task VerifyCodeFixAsync([StringSyntax("c#-test")] string source, DiagnosticResult expected, [StringSyntax("c#-test")] string? fixedSource = null, int? expectedIncrementalIterations = 1)
     {

--- a/CheckedExceptions.Tests/DictionaryTest.cs
+++ b/CheckedExceptions.Tests/DictionaryTest.cs
@@ -28,7 +28,7 @@ public partial class DictionaryTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
             .WithSpan(10, 14, 10, 28);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -76,7 +76,7 @@ public partial class DictionaryTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("KeyNotFoundException")
+        var expected = Verifier.UnhandledException("KeyNotFoundException")
             .WithSpan(10, 17, 10, 28);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/ExtensionMethods.cs
+++ b/CheckedExceptions.Tests/ExtensionMethods.cs
@@ -26,10 +26,10 @@ public partial class ExtensionMethods
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected1 = Verifier.UnhandledException("ArgumentNullException")
            .WithSpan(11, 23, 11, 30);
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
            .WithSpan(11, 23, 11, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
@@ -56,7 +56,7 @@ public partial class ExtensionMethods
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
            .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -83,7 +83,7 @@ public partial class ExtensionMethods
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
            .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -110,7 +110,7 @@ public partial class ExtensionMethods
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
            .WithSpan(12, 23, 12, 30);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/MemberAccessAndIdentifierNameTest.cs
+++ b/CheckedExceptions.Tests/MemberAccessAndIdentifierNameTest.cs
@@ -30,7 +30,7 @@ public partial class MemberAccessAndIdentifierNameTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(15, 14, 15, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -59,7 +59,7 @@ public partial class MemberAccessAndIdentifierNameTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(15, 9, 15, 14);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);
@@ -88,7 +88,7 @@ public partial class MemberAccessAndIdentifierNameTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(15, 14, 15, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);

--- a/CheckedExceptions.Tests/NullableContextTest.cs
+++ b/CheckedExceptions.Tests/NullableContextTest.cs
@@ -29,7 +29,7 @@ public partial class NullableContextTest
             """;
 
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(8, 9, 8, 28);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/RethrowsTest.cs
+++ b/CheckedExceptions.Tests/RethrowsTest.cs
@@ -34,7 +34,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(19, 13, 19, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -102,7 +102,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
          .WithSpan(17, 13, 17, 31);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -137,10 +137,10 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
          .WithSpan(20, 13, 20, 19);
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(20, 13, 20, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -182,10 +182,10 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
          .WithSpan(26, 13, 26, 19);
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(26, 13, 26, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -222,10 +222,10 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
          .WithSpan(21, 13, 21, 19);
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(21, 13, 21, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2);
@@ -261,7 +261,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(21, 13, 21, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -297,7 +297,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
             .WithSpan(21, 13, 21, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -365,13 +365,13 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("FormatException")
+        var expected = Verifier.UnhandledException("FormatException")
             .WithSpan(19, 13, 19, 19);
 
-        var expected2 = Verifier.MightBeThrown("OverflowException")
+        var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(19, 13, 19, 19);
 
-        var expected3 = Verifier.MightBeThrown("ArgumentOutOfRangeException")
+        var expected3 = Verifier.UnhandledException("ArgumentOutOfRangeException")
             .WithSpan(19, 13, 19, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected, expected2, expected3);
@@ -414,10 +414,10 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("ArgumentOutOfRangeException")
+        var expected1 = Verifier.UnhandledException("ArgumentOutOfRangeException")
             .WithSpan(28, 13, 28, 19);
 
-        var expected2 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(28, 13, 28, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
@@ -452,7 +452,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
             .WithSpan(20, 13, 20, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -487,7 +487,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("FormatException")
+        var expected = Verifier.UnhandledException("FormatException")
             .WithSpan(14, 13, 14, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -516,7 +516,7 @@ public partial class RethtrowsTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentException")
+        var expected = Verifier.UnhandledException("ArgumentException")
             .WithSpan(14, 13, 14, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/TryCatchTest.Nested.cs
+++ b/CheckedExceptions.Tests/TryCatchTest.Nested.cs
@@ -127,7 +127,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(12, 17, 12, 55); ;
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -163,7 +163,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(12, 17, 12, 55);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -199,7 +199,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.IsThrown("IOException")
+        var expected = Verifier.UnhandledException("IOException")
             .WithSpan(16, 17, 16, 41);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -240,10 +240,10 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected1 = Verifier.IsThrown("IOException")
+        var expected1 = Verifier.UnhandledException("IOException")
             .WithSpan(16, 17, 16, 41);
 
-        var expected2 = Verifier.IsThrown("FormatException")
+        var expected2 = Verifier.UnhandledException("FormatException")
             .WithSpan(20, 17, 20, 45);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2);
@@ -287,7 +287,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.IsThrown("IOException")
+        var expected = Verifier.UnhandledException("IOException")
             .WithSpan(16, 17, 16, 41);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/TryCatchTest.cs
+++ b/CheckedExceptions.Tests/TryCatchTest.cs
@@ -28,7 +28,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(14, 9, 14, 15);
 
 
@@ -51,7 +51,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.IsThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(8, 9, 8, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -81,10 +81,10 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected1 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(14, 9, 14, 15);
 
-        var expected2 = Verifier.IsThrown("InvalidOperationException")
+        var expected2 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(16, 9, 16, 47);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);
@@ -119,10 +119,10 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(20, 9, 20, 15);
 
-        var expected2 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected2 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(21, 9, 21, 15);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);
@@ -164,7 +164,7 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(23, 13, 23, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -249,10 +249,10 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(27, 13, 27, 19);
 
-        var expected2 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected2 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(27, 13, 27, 19);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);
@@ -302,10 +302,10 @@ public partial class TryCatchTest
         }
         """;
 
-        var expected1 = Verifier.MightBeThrown("InvalidOperationException")
+        var expected1 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(34, 17, 34, 23);
 
-        var expected2 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected2 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(34, 17, 34, 23);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected1, expected2]);

--- a/CheckedExceptions.Tests/XmlDocTest.cs
+++ b/CheckedExceptions.Tests/XmlDocTest.cs
@@ -34,7 +34,7 @@ public partial class XmlDocTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("InvalidOperationException")
+        var expected = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(16, 9, 16, 21);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);
@@ -56,13 +56,13 @@ public partial class XmlDocTest
             }
             """;
 
-        var expected1 = Verifier.MightBeThrown("ArgumentNullException")
+        var expected1 = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(7, 13, 7, 24);
 
-        var expected2 = Verifier.MightBeThrown("FormatException")
+        var expected2 = Verifier.UnhandledException("FormatException")
             .WithSpan(7, 13, 7, 24);
 
-        var expected3 = Verifier.MightBeThrown("OverflowException")
+        var expected3 = Verifier.UnhandledException("OverflowException")
             .WithSpan(7, 13, 7, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, expected1, expected2, expected3);
@@ -86,10 +86,10 @@ public partial class XmlDocTest
             }
             """;
 
-        var expected2 = Verifier.MightBeThrown("FormatException")
+        var expected2 = Verifier.UnhandledException("FormatException")
             .WithSpan(8, 13, 8, 24);
 
-        var expected3 = Verifier.MightBeThrown("OverflowException")
+        var expected3 = Verifier.UnhandledException("OverflowException")
             .WithSpan(8, 13, 8, 24);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected2, expected3]);
@@ -138,7 +138,7 @@ public partial class XmlDocTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentOutOfRangeException")
+        var expected = Verifier.UnhandledException("ArgumentOutOfRangeException")
             .WithSpan(11, 23, 11, 29);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);
@@ -173,7 +173,7 @@ public partial class XmlDocTest
             }
             """;
 
-        var expected = Verifier.MightBeThrown("ArgumentNullException")
+        var expected = Verifier.UnhandledException("ArgumentNullException")
             .WithSpan(20, 9, 20, 14);
 
         await Verifier.VerifyAnalyzerAsync(test, [expected]);

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Inheritance.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Inheritance.cs
@@ -63,7 +63,7 @@ partial class CheckedExceptionsAnalyzer
             if (!isCovered)
             {
                 var location = method.Locations.FirstOrDefault();
-                var baseName = $"{baseMethod.ContainingType.Name}.{baseMethod.Name}";
+                var baseName = FormatMethodSignature(baseMethod);
 
                 var diagnostic = Diagnostic.Create(
                     RuleMissingThrowsFromBaseMember,
@@ -87,7 +87,7 @@ partial class CheckedExceptionsAnalyzer
             if (!isCompatible)
             {
                 var location = method.Locations.FirstOrDefault();
-                var memberName = $"{baseMethod.ContainingType.Name}.{baseMethod.Name}";
+                var memberName = FormatMethodSignature(baseMethod);
 
                 var diagnostic = Diagnostic.Create(
                     RuleMissingThrowsOnBaseMember,
@@ -98,6 +98,18 @@ partial class CheckedExceptionsAnalyzer
                 context.ReportDiagnostic(diagnostic);
             }
         }
+    }
+
+    public static string FormatMethodSignature(IMethodSymbol methodSymbol)
+    {
+        var containingType = methodSymbol.ContainingType;
+        var typeName = containingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+
+        var methodName = methodSymbol.Name;
+        var parameters = string.Join(", ", methodSymbol.Parameters.Select(p =>
+            p.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+
+        return $"{typeName}.{methodName}({parameters})";
     }
 
     private bool IsTooGenericException(ITypeSymbol ex)

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -32,7 +32,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor RuleUnhandledException = new(
         DiagnosticIdUnhandled,
         "Unhandled exception",
-        "Exception '{0}' {1} thrown but not handled",
+        "Unhandled exception type '{0}'",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -50,7 +50,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor RuleGeneralThrow = new(
         DiagnosticIdGeneralThrow,
         "Avoid throwing 'Exception'",
-        "Throwing 'Exception' is too general; use a more specific exception type instead",
+        "Avoid throwing 'System.Exception'; use a more specific exception type",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -58,8 +58,8 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
     private static readonly DiagnosticDescriptor RuleGeneralThrows = new DiagnosticDescriptor(
         DiagnosticIdGeneralThrows,
-        "Avoid declaring exception type 'Exception'",
-        "Declaring 'Exception' is too general; use a more specific exception type instead",
+        "Avoid declaring exception type 'System.Exception'",
+        "Avoid declaring exception type 'System.Exception'; use a more specific exception type",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -77,7 +77,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor RuleMissingThrowsOnBaseMember = new DiagnosticDescriptor(
         DiagnosticIdMissingThrowsOnBaseMember,
         "Missing Throws declaration",
-        "Exception '{1}' is not declared on base member '{0}'",
+        "Exception '{1}' is not declared in '{0}'",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -86,7 +86,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor RuleMissingThrowsFromBaseMember = new(
         DiagnosticIdMissingThrowsFromBaseMember,
         "Missing Throws declaration for exception declared on base member",
-        "Base member '{0}' declares exception '{1}' which is not declared here",
+        "Exception '{1}' is not compatible with throws declaration in '{0}'",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -86,7 +86,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor RuleMissingThrowsFromBaseMember = new(
         DiagnosticIdMissingThrowsFromBaseMember,
         "Missing Throws declaration for exception declared on base member",
-        "Exception '{1}' is not compatible with throws declaration in '{0}'",
+        "Exception '{1}' is not compatible with throws declaration(s) in '{0}'",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -370,8 +370,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
                 var diagnostic = Diagnostic.Create(
                     RuleUnhandledException,
                     GetSignificantLocation(throwStatement),
-                    exceptionType.Name,
-                    THROW001Verbs.MightBe);
+                    exceptionType.Name);
 
                 context.ReportDiagnostic(diagnostic);
             }
@@ -1237,11 +1236,7 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
             var properties = ImmutableDictionary.Create<string, string?>()
                 .Add("ExceptionType", exceptionType.Name);
 
-            var isThrowingConstruct = node is ThrowStatementSyntax or ThrowExpressionSyntax;
-
-            var verb = isThrowingConstruct ? THROW001Verbs.Is : THROW001Verbs.MightBe;
-
-            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetSignificantLocation(node), properties, exceptionType.Name, verb);
+            var diagnostic = Diagnostic.Create(RuleUnhandledException, GetSignificantLocation(node), properties, exceptionType.Name);
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/CheckedExceptions/THROW001Verbs.cs
+++ b/CheckedExceptions/THROW001Verbs.cs
@@ -1,7 +1,0 @@
-namespace Sundstrom.CheckedExceptions;
-
-public static class THROW001Verbs
-{
-    public const string Is = "is";
-    public const string MightBe = "might be";
-}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public class Sample
 {
     public void Execute()
     {
-        // ⚠️ THROW001: Unhandled exception
+        // ⚠️ THROW001: Unhandled exception type 'InvalidOperationException'
         Perform();
     }
 

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -241,7 +241,7 @@ public void Foo()
 When unhandled at call site:
 
 ```csharp
-// THROW001: Exception "InvalidOperationException" might be thrown but not handled
+// THROW001: Unhandled exception type "InvalidOperationException"
 
 Foo();
 ```
@@ -280,8 +280,8 @@ public void Foo()
 When unhandled at call site:
 
 ```csharp
-// THROW001: Exception "ArgumentOutOfRangeException" might be thrown but not handled
-// THROW001: Exception "InvalidOperationException" might be thrown but not handled
+// THROW001: Unhandled exception type "ArgumentOutOfRangeException"
+// THROW001: Unhandled exception type "InvalidOperationException"
 
 Foo();
 ```


### PR DESCRIPTION
Align diagnostic messages with Java's, for clarity.

Example 1: `Unhandled exception type 'UnknownHostException'`

Example 2: `Exception 'IOException' is not compatible with throws declaration in 'IOperation.Execute()'`

<img width="604" height="172" alt="Screenshot 2025-07-22 at 23 12 13" src="https://github.com/user-attachments/assets/f41586c7-aa36-445b-93c5-9366d147d595" />

Make sure to remove the usage of "verbs" ("Might be" and so on) from the analyzer and tests.