### PR TITLE
Generate descriptive variable names for catch clauses #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- PR [#99](https://github.com/marinasundstrom/CheckedExceptions/pull/99) Generate descriptive variable names for catch clauses
+
 ## [1.4.1] - 2025-07-25
 
 ### Added

--- a/CheckedExceptions.CodeFixes/AddTryCatchBlockCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddTryCatchBlockCodeFixProvider.cs
@@ -9,174 +9,139 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static CatchClauseUtils;
 
-namespace Sundstrom.CheckedExceptions
+namespace Sundstrom.CheckedExceptions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddTryCatchBlockCodeFixProvider)), Shared]
+public class AddTryCatchBlockCodeFixProvider : CodeFixProvider
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddTryCatchBlockCodeFixProvider)), Shared]
-    public class AddTryCatchBlockCodeFixProvider : CodeFixProvider
+    private const string TitleAddTryCatch = "Surround with try/catch";
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        private const string TitleAddTryCatch = "Surround with try/catch";
+        var diagnostics = context.Diagnostics;
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
-            [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
+        var cancellationToken = context.CancellationToken;
+        var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var diagnostic = diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
 
-        public sealed override FixAllProvider GetFixAllProvider() =>
-            WellKnownFixAllProviders.BatchFixer;
+        // Register the code fix only if the node is a statement or within a statement
+        var statement = node.FirstAncestorOrSelf<StatementSyntax>();
+        if (statement is null)
+            return;
 
-        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: TitleAddTryCatch,
+                createChangedDocument: c => AddTryCatchAsync(context.Document, statement, diagnostics, c),
+                equivalenceKey: TitleAddTryCatch),
+            diagnostics);
+    }
+
+    private async Task<Document> AddTryCatchAsync(Document document, StatementSyntax statement, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    {
+        // Retrieve exception types from diagnostics
+        var exceptionTypeNames = diagnostics
+            .Select(diagnostic => diagnostic.Properties.ContainsKey("ExceptionType") ? diagnostic.Properties["ExceptionType"]! : string.Empty);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root is null)
         {
-            var diagnostics = context.Diagnostics;
-
-            var cancellationToken = context.CancellationToken;
-            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var diagnostic = diagnostics.First();
-            var node = root.FindNode(diagnostic.Location.SourceSpan);
-
-            // Register the code fix only if the node is a statement or within a statement
-            var statement = node.FirstAncestorOrSelf<StatementSyntax>();
-            if (statement is null)
-                return;
-
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    title: TitleAddTryCatch,
-                    createChangedDocument: c => AddTryCatchAsync(context.Document, statement, diagnostics, c),
-                    equivalenceKey: TitleAddTryCatch),
-                diagnostics);
+            return document;
         }
 
-        private async Task<Document> AddTryCatchAsync(Document document, StatementSyntax statement, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        var parentBlock = statement.Parent as BlockSyntax;
+        if (parentBlock is null)
+            return document; // Cannot proceed if the parent is not a block
+
+        var statements = parentBlock.Statements;
+        var targetIndex = statements.IndexOf(statement);
+
+        if (targetIndex is -1)
+            return document; // Statement not found in the parent block
+
+        // Perform data flow analysis on the target statement
+        var dataFlow = semanticModel.AnalyzeDataFlow(statement)!;
+
+        var variablesToTrack = new HashSet<ISymbol>(dataFlow.ReadInside.Concat(dataFlow.WrittenInside), SymbolEqualityComparer.Default);
+
+        // Determine the range of statements to include using flow analysis
+        int start = targetIndex;
+        int end = targetIndex;
+
+        // Expand upwards to include related statements
+        for (int i = targetIndex - 1; i >= 0; i--)
         {
-            // Retrieve exception types from diagnostics
-            var exceptionTypeNames = diagnostics
-                .Select(diagnostic => diagnostic.Properties.ContainsKey("ExceptionType") ? diagnostic.Properties["ExceptionType"]! : string.Empty);
+            var currentStatement = statements[i];
+            var currentDataFlow = semanticModel.AnalyzeDataFlow(currentStatement)!;
 
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            if (root is null)
+            if (currentDataFlow.WrittenOutside.Any(v => variablesToTrack.Contains(v)) ||
+                currentDataFlow.ReadInside.Any(v => variablesToTrack.Contains(v)))
             {
-                return document;
-            }
-
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            var parentBlock = statement.Parent as BlockSyntax;
-            if (parentBlock is null)
-                return document; // Cannot proceed if the parent is not a block
-
-            var statements = parentBlock.Statements;
-            var targetIndex = statements.IndexOf(statement);
-
-            if (targetIndex is -1)
-                return document; // Statement not found in the parent block
-
-            // Perform data flow analysis on the target statement
-            var dataFlow = semanticModel.AnalyzeDataFlow(statement)!;
-
-            var variablesToTrack = new HashSet<ISymbol>(dataFlow.ReadInside.Concat(dataFlow.WrittenInside), SymbolEqualityComparer.Default);
-
-            // Determine the range of statements to include using flow analysis
-            int start = targetIndex;
-            int end = targetIndex;
-
-            // Expand upwards to include related statements
-            for (int i = targetIndex - 1; i >= 0; i--)
-            {
-                var currentStatement = statements[i];
-                var currentDataFlow = semanticModel.AnalyzeDataFlow(currentStatement)!;
-
-                if (currentDataFlow.WrittenOutside.Any(v => variablesToTrack.Contains(v)) ||
-                    currentDataFlow.ReadInside.Any(v => variablesToTrack.Contains(v)))
-                {
-                    start = i;
-                    variablesToTrack.UnionWith(currentDataFlow.ReadInside);
-                    variablesToTrack.UnionWith(currentDataFlow.WrittenInside);
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            // Expand downwards to include related statements
-            for (int i = targetIndex + 1; i < statements.Count; i++)
-            {
-                var currentStatement = statements[i];
-                var currentDataFlow = semanticModel.AnalyzeDataFlow(currentStatement)!;
-
-                if (currentDataFlow.ReadOutside.Any(v => variablesToTrack.Contains(v)) ||
-                    currentDataFlow.WrittenInside.Any(v => variablesToTrack.Contains(v)))
-                {
-                    end = i;
-                    variablesToTrack.UnionWith(currentDataFlow.ReadInside);
-                    variablesToTrack.UnionWith(currentDataFlow.WrittenInside);
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            // Extract the related statements
-            var statementsToWrap = statements.Skip(start).Take(end - start + 1).ToList();
-
-            // Create the try block
-            var tryBlock = Block(statementsToWrap)
-                .WithAdditionalAnnotations(Formatter.Annotation);
-
-            var count = statementsToWrap.First().Ancestors().OfType<TryStatementSyntax>().Count();
-
-            // Create catch clauses based on exception types
-            List<CatchClauseSyntax> catchClauses = CreateCatchClauses(exceptionTypeNames, count);
-
-            // Construct the try-catch statement
-            TryStatementSyntax tryCatchStatement = TryStatement()
-                .WithBlock(tryBlock)
-                .WithCatches(List(catchClauses))
-                .WithAdditionalAnnotations(Formatter.Annotation);
-
-            // Replace the original statements with the try-catch statement
-            var newRootReplace = root.ReplaceNodes(
-                statementsToWrap,
-                (original, rewritten) => original == statementsToWrap.First() ? tryCatchStatement.WithAdditionalAnnotations(Formatter.Annotation) : null!
-            );
-
-            return document.WithSyntaxRoot(newRootReplace);
-        }
-
-        private static List<CatchClauseSyntax> CreateCatchClauses(IEnumerable<string> exceptionTypeNames, int level = 0)
-        {
-            List<CatchClauseSyntax> catchClauses = new List<CatchClauseSyntax>();
-
-            string catchExceptionVariableName;
-
-            if (level is 0)
-            {
-                catchExceptionVariableName = "ex";
+                start = i;
+                variablesToTrack.UnionWith(currentDataFlow.ReadInside);
+                variablesToTrack.UnionWith(currentDataFlow.WrittenInside);
             }
             else
             {
-                catchExceptionVariableName = $"ex{level + 1}";
+                break;
             }
-
-            foreach (var exceptionTypeName in exceptionTypeNames.Distinct())
-            {
-                if (string.IsNullOrWhiteSpace(exceptionTypeName))
-                    continue;
-
-                var exceptionType = ParseTypeName(exceptionTypeName);
-
-                var catchClause = CatchClause()
-                    .WithDeclaration(
-                        CatchDeclaration(exceptionType)
-                        .WithIdentifier(Identifier(catchExceptionVariableName)))
-                    .WithBlock(Block()) // You might want to add meaningful handling here
-                    .WithAdditionalAnnotations(Formatter.Annotation);
-
-                catchClauses.Add(catchClause);
-            }
-
-            return catchClauses;
         }
+
+        // Expand downwards to include related statements
+        for (int i = targetIndex + 1; i < statements.Count; i++)
+        {
+            var currentStatement = statements[i];
+            var currentDataFlow = semanticModel.AnalyzeDataFlow(currentStatement)!;
+
+            if (currentDataFlow.ReadOutside.Any(v => variablesToTrack.Contains(v)) ||
+                currentDataFlow.WrittenInside.Any(v => variablesToTrack.Contains(v)))
+            {
+                end = i;
+                variablesToTrack.UnionWith(currentDataFlow.ReadInside);
+                variablesToTrack.UnionWith(currentDataFlow.WrittenInside);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        // Extract the related statements
+        var statementsToWrap = statements.Skip(start).Take(end - start + 1).ToList();
+
+        // Create the try block
+        var tryBlock = Block(statementsToWrap)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var count = statementsToWrap.First().Ancestors().OfType<TryStatementSyntax>().Count();
+
+        // Create catch clauses based on exception types
+        List<CatchClauseSyntax> catchClauses = CreateCatchClauses(exceptionTypeNames, count);
+
+        // Construct the try-catch statement
+        TryStatementSyntax tryCatchStatement = TryStatement()
+            .WithBlock(tryBlock)
+            .WithCatches(List(catchClauses))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        // Replace the original statements with the try-catch statement
+        var newRootReplace = root.ReplaceNodes(
+            statementsToWrap,
+            (original, rewritten) => original == statementsToWrap.First() ? tryCatchStatement.WithAdditionalAnnotations(Formatter.Annotation) : null!
+        );
+
+        return document.WithSyntaxRoot(newRootReplace);
     }
 }

--- a/CheckedExceptions.CodeFixes/CatchClauseUtils.cs
+++ b/CheckedExceptions.CodeFixes/CatchClauseUtils.cs
@@ -1,0 +1,54 @@
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+public static class CatchClauseUtils
+{
+    public static List<CatchClauseSyntax> CreateCatchClauses(IEnumerable<string> exceptionTypeNames, int level = 0)
+    {
+        List<CatchClauseSyntax> catchClauses = new List<CatchClauseSyntax>();
+
+        foreach (var exceptionTypeName in exceptionTypeNames.Distinct())
+        {
+            if (string.IsNullOrWhiteSpace(exceptionTypeName))
+                continue;
+
+            string catchExceptionVariableName = CreateVariableName(exceptionTypeName);
+
+            var exceptionType = ParseTypeName(exceptionTypeName);
+
+            var catchClause = CatchClause()
+                .WithDeclaration(
+                    CatchDeclaration(exceptionType)
+                    .WithIdentifier(Identifier(catchExceptionVariableName)))
+                .WithBlock(Block()) // You might want to add meaningful handling here
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            catchClauses.Add(catchClause);
+        }
+
+        return catchClauses;
+    }
+
+    private static string CreateVariableName(string exceptionTypeName)
+    {
+        if (exceptionTypeName is "Exception" or "System.Exception")
+        {
+            return "ex";
+        }
+
+        // Get the simple type name (strip namespace if present)
+        var simpleName = exceptionTypeName.Contains('.')
+        ? exceptionTypeName.Substring(exceptionTypeName.LastIndexOf('.') + 1)
+        : exceptionTypeName;
+
+        // Convert to camelCase
+        if (string.IsNullOrEmpty(simpleName) || char.IsLower(simpleName[0]))
+            return simpleName;
+
+        return char.ToLower(simpleName[0]) + simpleName.Substring(1);
+    }
+}

--- a/CheckedExceptions.Tests/CodeFixes/AddCatchClauseToTryCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/AddCatchClauseToTryCodeFixProviderTests.cs
@@ -53,7 +53,7 @@ namespace TestNamespace
             catch (InvalidOperationException ex)
             {
             }
-            catch (ArgumentException ex2)
+            catch (ArgumentException argumentException)
             {
             }
         }

--- a/CheckedExceptions.Tests/CodeFixes/AddTryCatchBlockCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/AddTryCatchBlockCodeFixProviderTests.cs
@@ -22,6 +22,54 @@ namespace TestNamespace
         public void TestMethod()
         {
             // Should trigger THROW001
+            throw new ArgumentException();
+        }
+    }
+}
+""";
+
+        var fixedCode = /* lang=c#-test */  """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            try
+            {
+                // Should trigger THROW001
+                throw new ArgumentException();
+            }
+            catch (ArgumentException argumentException)
+            {
+            }
+        }
+    }
+}
+""";
+
+        var expectedDiagnostic = Verifier.UnhandledException("ArgumentException")
+            .WithSpan(10, 13, 10, 43);
+
+        await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode);
+    }
+
+
+    [Fact]
+    public async Task WhenExceptionTypeIsException_VariableName_ShouldBe_Ex()
+    {
+        var testCode = /* lang=c#-test */  """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            // Should trigger THROW001
             throw new Exception();
         }
     }
@@ -95,7 +143,7 @@ namespace TestNamespace
                 // Should trigger THROW001
                 DoSomething();
             }
-            catch (InvalidOperationException ex)
+            catch (InvalidOperationException invalidOperationException)
             {
             }
         }
@@ -228,7 +276,7 @@ namespace TestNamespace
                     // Should trigger THROW001
                     DoSomething();
                 }
-                catch (InvalidOperationException ex2)
+                catch (InvalidOperationException exc2)
                 {
                 }
             }


### PR DESCRIPTION
Generate descriptive variable names for catch clauses. Also made some refactoring.

Following this pattern:

Normal: `InvalidOperationException invalidOperationException` 

Exception: `Exception ex` 