### PR TITLE
Handle redundant typed catch #114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- PR [#117](https://github.com/marinasundstrom/CheckedExceptions/pull/#117) Handle redundant typed catch #114
+
 ## [1.5.2] - 2025-07-26
 
 ## Added

--- a/CheckedExceptions.CodeFixes/RemoveRedundantCatchClauseCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/RemoveRedundantCatchClauseCodeFixProvider.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static CatchClauseUtils;
+
+namespace Sundstrom.CheckedExceptions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RemoveRedundantCatchClauseCodeFixProvider)), Shared]
+public class RemoveRedundantCatchClauseCodeFixProvider : CodeFixProvider
+{
+    private const string TitleRemoveRedundantCatchClause = "Remove redundant catch clause";
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [CheckedExceptionsAnalyzer.DiagnosticIdRedundantTypedCatchClause];
+
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostics = context.Diagnostics;
+        var cancellationToken = context.CancellationToken;
+        var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var diagnostic = diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+        var catchClause = node.AncestorsAndSelf().OfType<CatchClauseSyntax>().First();
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: TitleRemoveRedundantCatchClause,
+                createChangedDocument: c => RemoveRedundantCatchClauseAsync(context.Document, catchClause, diagnostics, c),
+                equivalenceKey: TitleRemoveRedundantCatchClause),
+            diagnostics);
+    }
+
+    private async Task<Document> RemoveRedundantCatchClauseAsync(Document document, CatchClauseSyntax catchClause, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    {
+        var exceptionTypeNames = diagnostics
+            .Select(d => d.Properties.TryGetValue("ExceptionType", out var type) ? type! : string.Empty);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null) return document;
+
+        var newRoot = root.RemoveNode(catchClause, SyntaxRemoveOptions.AddElasticMarker);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
+++ b/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
@@ -59,6 +59,8 @@ public static class CSharpAnalyzerVerifier<TAnalyzer, TVerifier>
             {
                 var allDiagnostics = CheckedExceptionsAnalyzer.AllDiagnosticsIds;
 
+                test.DisabledDiagnostics.Add("THROW009");
+
                 test.DisabledDiagnostics.AddRange(allDiagnostics.Except(expected.Select(x => x.Id)));
             }
 
@@ -103,6 +105,8 @@ public static class CSharpAnalyzerVerifier<TAnalyzer, TVerifier>
 
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(ThrowsAttribute).Assembly.Location));
         test.TestState.ReferenceAssemblies = Net.Net90;
+
+        test.DisabledDiagnostics.Add("THROW009");
 
         if (executable)
         {

--- a/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
+++ b/CheckedExceptions.Tests/CSharpAnalyzerVerifier.cs
@@ -43,9 +43,13 @@ public static class CSharpAnalyzerVerifier<TAnalyzer, TVerifier>
         => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW007")
         .WithArguments(memberName, exceptionType);
 
-    public static DiagnosticResult RedundantExceptionDeclaration(string exceptionType)
+    public static DiagnosticResult RedundantExceptionDeclarationBySuperType(string exceptionType)
             => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW008")
             .WithArguments(exceptionType);
+
+    public static DiagnosticResult RedundantTypedCatchClause(string exceptionType)
+        => AnalyzerVerifier<TAnalyzer, AnalyzerTest, TVerifier>.Diagnostic("THROW009")
+        .WithArguments(exceptionType);
 
     public static async Task VerifyAnalyzerAsync([StringSyntax("c#-test")] string source, params DiagnosticResult[] expected)
     {

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.DeclaredSuperClassDetection.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.DeclaredSuperClassDetection.cs
@@ -24,7 +24,7 @@ partial class CheckedExceptionsAnalyzerTests
             }
             """;
 
-        var expected = Verifier.RedundantExceptionDeclaration("System.InvalidOperationException")
+        var expected = Verifier.RedundantExceptionDeclarationBySuperType("System.InvalidOperationException")
             .WithSpan(6, 13, 6, 44);
 
         await Verifier.VerifyAnalyzerAsync(test, expected);

--- a/CheckedExceptions.Tests/CodeFixes/RemoveRedundantCatchClauseCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/RemoveRedundantCatchClauseCodeFixProviderTests.cs
@@ -1,0 +1,57 @@
+namespace Sundstrom.CheckedExceptions.Tests.CodeFixes;
+
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, RemoveRedundantCatchClauseCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+public class RemoveRedundantCatchClauseCodeFixProviderTests
+{
+    [Fact]
+    public async Task RemoveCatchBlock()
+    {
+        var testCode = /* lang=c#-test */  """
+#nullable enable
+using System;
+
+try
+{
+    int.Parse("a");
+}
+catch (FormatException formatException)
+{
+}
+catch (OverflowException overflowException)
+{
+}
+catch (ArgumentException argumentException)
+{
+}
+""";
+
+        var fixedCode = /* lang=c#-test */  """
+#nullable enable
+using System;
+
+try
+{
+    int.Parse("a");
+}
+catch (FormatException formatException)
+{
+}
+catch (OverflowException overflowException)
+{
+}
+""";
+
+        var expectedDiagnostic = Verifier.Diagnostic("THROW009")
+                .WithArguments("System.ArgumentException")
+                .WithSpan(14, 8, 14, 25);
+
+
+        await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode, executable: true);
+    }
+}

--- a/CheckedExceptions.Tests/TryCatchTest.RedundantCatch.cs
+++ b/CheckedExceptions.Tests/TryCatchTest.RedundantCatch.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Sundstrom.CheckedExceptions.Tests;
+
+using Verifier = CSharpAnalyzerVerifier<CheckedExceptionsAnalyzer, DefaultVerifier>;
+
+public partial class TryCatchTest
+{
+    [Fact]
+    public async Task RedundantTypedCatchClause()
+    {
+        var test = /* lang=c#-test */ """
+            #nullable enable
+            using System;
+
+            try
+            {
+                int.Parse("a");
+            }
+            catch (FormatException formatException)
+            {
+            }
+            catch (OverflowException overflowException)
+            {
+            }
+            catch (ArgumentException argumentException)
+            {
+            }
+            """;
+
+        var expected = Verifier.RedundantTypedCatchClause("System.ArgumentException")
+            .WithSpan(14, 8, 14, 25);
+
+        await Verifier.VerifyAnalyzerAsync(test, setup: (ex) => { ex.ExpectedDiagnostics.Add(expected); }, executable: true);
+
+        //await Verifier.VerifyAnalyzerAsync(test, executable: true);
+    }
+}

--- a/CheckedExceptions.Tests/TryCatchTest.RedundantCatch.cs
+++ b/CheckedExceptions.Tests/TryCatchTest.RedundantCatch.cs
@@ -32,7 +32,12 @@ public partial class TryCatchTest
         var expected = Verifier.RedundantTypedCatchClause("System.ArgumentException")
             .WithSpan(14, 8, 14, 25);
 
-        await Verifier.VerifyAnalyzerAsync(test, setup: (ex) => { ex.ExpectedDiagnostics.Add(expected); }, executable: true);
+        await Verifier.VerifyAnalyzerAsync(test, setup: (ex) =>
+        {
+            // Enables THROW009
+            ex.DisabledDiagnostics.Clear();
+            ex.ExpectedDiagnostics.Add(expected);
+        }, executable: true);
 
         //await Verifier.VerifyAnalyzerAsync(test, executable: true);
     }

--- a/CheckedExceptions/AnalyzerReleases.Unshipped.md
+++ b/CheckedExceptions/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ THROW005 | Usage   | Warning  | CheckedExceptionsAnalyzer
 THROW006 | Usage   | Warning  | CheckedExceptionsAnalyzer
 THROW007 | Usage   | Warning  | CheckedExceptionsAnalyzer
 THROW008 | Usage   | Warning  | CheckedExceptionsAnalyzer
+THROW009 | Usage   | Warning  | CheckedExceptionsAnalyzer

--- a/SampleProject/Program.cs
+++ b/SampleProject/Program.cs
@@ -1,36 +1,13 @@
 ﻿try
 {
-    int result = ReadAndParse();
-    Console.WriteLine(result);
+    int.Parse("a");
 }
-catch (InvalidUserInputException ex)
+catch (FormatException formatException)
 {
-    Console.WriteLine($"Input error: {ex.Message}");
 }
-
-[Throws(typeof(InvalidUserInputException))] // ✔️ Only the domain-specific exception is exposed
-static int ReadAndParse()
+catch (OverflowException overflowException)
 {
-    string input = "abc";  // Simulated input — could be user input in real scenarios
-
-    try
-    {
-        return int.Parse(input);
-    }
-    catch (FormatException formatException)
-    {
-        // Handle and rethrow as domain-specific exception
-        throw new InvalidUserInputException("Input was not a valid number.", formatException);
-    }
-    catch (OverflowException overflowException)
-    {
-        // Handle and rethrow as domain-specific exception
-        throw new InvalidUserInputException("Input number was too large.", overflowException);
-    }
 }
-
-class InvalidUserInputException : Exception
+catch (ArgumentException argumentException)
 {
-    public InvalidUserInputException(string message, Exception inner)
-        : base(message, inner) { }
 }

--- a/Test/RedundantCatchClause.cs
+++ b/Test/RedundantCatchClause.cs
@@ -1,0 +1,20 @@
+public class RedundantCatchClause
+{
+    public void Foo()
+    {
+
+        try
+        {
+            int.Parse("a");
+        }
+        catch (FormatException formatException)
+        {
+        }
+        catch (OverflowException overflowException)
+        {
+        }
+        catch (ObjectDisposedException argumentException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Includes analyzer and code fix for removing the `catch` clause.

Unit tests