### PR TITLE
Prevent catch clause fix from appearing inside try-wrapped lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PR [#121](https://github.com/marinasundstrom/CheckedExceptions/pull/#121) Remove leading trivia before adding ThrowsAttribute
+- PR [#122](https://github.com/marinasundstrom/CheckedExceptions/pull/#122) Prevent catch clause fix from appearing inside try-wrapped lambdas
 
 ## [1.5.2] - 2025-07-26
 

--- a/CheckedExceptions.Tests/CodeFixes/BugFixes/BugFix120_FixWronglyOfferedInLambdaInsideTry.cs
+++ b/CheckedExceptions.Tests/CodeFixes/BugFixes/BugFix120_FixWronglyOfferedInLambdaInsideTry.cs
@@ -1,0 +1,138 @@
+namespace Sundstrom.CheckedExceptions.Tests.CodeFixes.BugFixes;
+
+using System.Threading.Tasks;
+
+using Xunit;
+
+using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, AddCatchClauseToTryCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+public class BugFix120_FixWronglyOfferedInLambdaInsideTry
+{
+    [Fact]
+    public async Task FixNotOffered_WhenThrowInsideLambdaBody_DeclaredInTryBlock()
+    {
+        var testCode = /*lang=c#-test*/ """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            try
+            {
+                Action action = () =>
+                {
+                    throw new InvalidOperationException();
+                };
+                action();
+            }
+            catch {}
+        }
+    }
+}
+""";
+
+        var expected = /*lang=c#-test*/ """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            try
+            {
+                Action action = () =>
+                {
+                    throw new InvalidOperationException();
+                };
+                action();
+            }
+            catch {}
+        }
+    }
+}
+""";
+
+        // Expect no fix to be registered
+        await Verifier.VerifyCodeFixAsync(testCode, [], expected, expectedIncrementalIterations: 0);
+    }
+
+    [Fact]
+    public async Task FixOffered_WhenThrowInsideTryBlock_InLambdaBody()
+    {
+        var testCode = /*lang=c#-test*/ """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            try
+            {
+                Action action = () =>
+                {
+                    try
+                    {
+                        throw new ArgumentException();
+
+                        throw new InvalidOperationException();
+                    }
+                    catch (ArgumentException argumentException)
+                    {
+                    }
+                };
+                action();
+            }
+            catch {}
+        }
+    }
+}
+""";
+
+        var expected = /*lang=c#-test*/ """
+using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            try
+            {
+                Action action = () =>
+                {
+                    try
+                    {
+                        throw new ArgumentException();
+
+                        throw new InvalidOperationException();
+                    }
+                    catch (ArgumentException argumentException)
+                    {
+                    }
+                    catch (InvalidOperationException invalidOperationException)
+                    {
+                    }
+                };
+                action();
+            }
+            catch {}
+        }
+    }
+}
+""";
+
+        var expectedDiagnostic = Verifier.UnhandledException("InvalidOperationException")
+            .WithSpan(17, 25, 17, 63);
+
+        // Expect no fix to be registered
+        await Verifier.VerifyCodeFixAsync(testCode, [expectedDiagnostic], expected);
+    }
+}


### PR DESCRIPTION
The code fix shouldn't be available in lambda expression or local function just because of enclosing `try`.