### PR TITLE
Prepare for wrap strategies to "Surround with try/catch" fix #160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- PR [#161](https://github.com/marinasundstrom/CheckedExceptions/pull/161) Prepare for wrap strategies for "Surround with try/catch" fix
+
 ## [1.6.7] - 2025-07-29
 
 ### Added

--- a/CheckedExceptions.CodeFixes/SurroundWithTryCatchCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/SurroundWithTryCatchCodeFixProvider.cs
@@ -51,7 +51,7 @@ public class SurroundWithTryCatchCodeFixProvider : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: TitleAddTryCatch,
-                createChangedDocument: c => AddTryCatchAroundStatementAsync(context.Document, statement, diagnostics, WrapStrategy.Minimal, c),
+                createChangedDocument: c => AddTryCatchAroundStatementAsync(context.Document, statement, diagnostics, WrapStrategy.MinimalTransitive, c),
                 equivalenceKey: TitleAddTryCatch),
             diagnostics);
     }

--- a/CheckedExceptions.Tests/CodeFixes/SurroundWithTryCatchCodeFixProviderTests.WrapStrategies.cs
+++ b/CheckedExceptions.Tests/CodeFixes/SurroundWithTryCatchCodeFixProviderTests.WrapStrategies.cs
@@ -1,0 +1,50 @@
+namespace Sundstrom.CheckedExceptions.Tests.CodeFixes;
+
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Testing;
+
+using Xunit;
+using Xunit.Abstractions;
+
+using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, SurroundWithTryCatchCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+public partial class SurroundWithTryCatchCodeFixProviderTests
+{
+    [Fact]
+    public async Task MinimalTransitive()
+    {
+        var testCode = /* lang=c#-test */  """
+using System;
+
+var a = "1";
+string str = a + "2";
+var x = Parse(str);
+
+[Throws(typeof(ArgumentException))]
+int Parse(string str) => 0;
+""";
+
+        var fixedCode = /* lang=c#-test */  """
+using System;
+
+try
+{
+    var a = "1";
+    string str = a + "2";
+    var x = Parse(str);
+}
+catch (ArgumentException argumentException)
+{
+}
+
+[Throws(typeof(ArgumentException))]
+int Parse(string str) => 0;
+""";
+
+        var expectedDiagnostic = Verifier.UnhandledException("ArgumentException")
+            .WithSpan(5, 9, 5, 19);
+
+        await Verifier.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedCode, executable: true);
+    }
+}

--- a/CheckedExceptions.Tests/CodeFixes/SurroundWithTryCatchCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/SurroundWithTryCatchCodeFixProviderTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, SurroundWithTryCatchCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
-public class SurroundWithTryCatchCodeFixProviderTests
+public partial class SurroundWithTryCatchCodeFixProviderTests
 {
     [Fact]
     public async Task AddTryCatch_ToMethod_WhenUnhandledExceptionThrown()


### PR DESCRIPTION
We might not surface the option just yet.

But we set the default to "MinimalTransitive" - the original was just what now call "Minimal".

Other options: "Remainder" and "FullBlock"