### PR TITLE
Improve robustness for redundancy check and inheritance

### DIFF
--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Inheritance.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Inheritance.cs
@@ -32,7 +32,7 @@ partial class CheckedExceptionsAnalyzerTests
 
         await Verifier.VerifyAnalyzerAsync(test, s =>
         {
-            s.DisabledDiagnostics.Add("THROW003");
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
         });
     }
 
@@ -61,7 +61,7 @@ partial class CheckedExceptionsAnalyzerTests
         """;
 
         var expected = Verifier.MissingThrowsOnBaseMember("IOException", "BaseService.DoWork()")
-            .WithSpan(14, 26, 14, 32);
+            .WithSpan(13, 20, 13, 31);
 
         var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "BaseService.DoWork()")
             .WithSpan(14, 26, 14, 32);
@@ -95,7 +95,7 @@ partial class CheckedExceptionsAnalyzerTests
         """;
 
         var expected = Verifier.MissingThrowsOnBaseMember("SocketException", "IOperation.Execute()")
-            .WithSpan(15, 17, 15, 24);
+            .WithSpan(14, 20, 14, 35);
 
         var expected2 = Verifier.MissingThrowsFromBaseMember("IOException", "IOperation.Execute()")
             .WithSpan(15, 17, 15, 24);
@@ -131,7 +131,7 @@ partial class CheckedExceptionsAnalyzerTests
         """;
 
         var expected = Verifier.MissingThrowsOnBaseMember("IOException", "Base.get_Value()")
-            .WithSpan(19, 9, 19, 12);
+            .WithSpan(18, 24, 18, 35);
 
         var expected2 = Verifier.MissingThrowsFromBaseMember("InvalidOperationException", "Base.get_Value()")
             .WithSpan(19, 9, 19, 12);
@@ -168,7 +168,7 @@ partial class CheckedExceptionsAnalyzerTests
         """;
 
         var expected = Verifier.MissingThrowsOnBaseMember("UnauthorizedAccessException", "Base.add_Something(EventHandler)")
-            .WithSpan(19, 9, 19, 12);
+            .WithSpan(18, 24, 18, 51);
 
         var expected2 = Verifier.MissingThrowsFromBaseMember("NotSupportedException", "Base.add_Something(EventHandler)")
             .WithSpan(19, 9, 19, 12);
@@ -204,7 +204,7 @@ partial class CheckedExceptionsAnalyzerTests
 
         await Verifier.VerifyAnalyzerAsync(test, s =>
         {
-            s.DisabledDiagnostics.Add("THROW003");
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
         });
     }
 
@@ -238,7 +238,7 @@ partial class CheckedExceptionsAnalyzerTests
 
         await Verifier.VerifyAnalyzerAsync(test, s =>
         {
-            s.DisabledDiagnostics.Add("THROW003");
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
         });
     }
 }

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.RobustnessCheck.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.RobustnessCheck.cs
@@ -1,0 +1,78 @@
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Sundstrom.CheckedExceptions.Tests;
+
+using Verifier = CSharpAnalyzerVerifier<CheckedExceptionsAnalyzer, DefaultVerifier>;
+
+partial class CheckedExceptionsAnalyzerTests
+{
+    [Fact]
+    public async Task DeclareExceptionOnExpressionBodiesPropThatDoesntThrowType_Diagnostic()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class TestBase
+        {
+            [Throws(typeof(ArgumentException))]
+            public bool Foo2 => true;
+        }
+        """;
+
+        var expected = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("ArgumentException")
+            .WithSpan(5, 20, 5, 37);
+
+        await Verifier.VerifyAnalyzerAsync(test, s =>
+        {
+            s.ExpectedDiagnostics.Add(expected);
+
+            s.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
+        });
+    }
+
+    [Fact]
+    public async Task DeclareExceptionOnExpressionBodiesPropThatThrowsType_NoDiagnostic()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class TestBase
+        {
+            [Throws(typeof(ArgumentException))]
+            public bool Foo2 => throw new ArgumentException();
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(test, s =>
+        {
+            s.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
+        });
+    }
+
+
+    [Fact]
+    public async Task DeclareThrowsOnVirtualFullProperty_NoDiagnostic()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class TestBase
+        {
+            [Throws(typeof(ArgumentException))]
+            public virtual bool Foo2 { get; set; }
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(test, s =>
+        {
+            s.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+
+            s.DisabledDiagnostics.Add(CheckedExceptionsAnalyzer.DiagnosticIdGeneralThrows);
+        });
+    }
+}

--- a/Test/Inheritance.cs
+++ b/Test/Inheritance.cs
@@ -61,8 +61,11 @@ public class TestBase
     [Throws(typeof(InvalidDataException))]
     public virtual bool Foo => throw new InvalidDataException();
 
-    [Throws(typeof(InvalidOperationException))]
-    public virtual bool Foo2 => throw new InvalidOperationException();
+    [Throws(typeof(ArgumentException))]
+    public virtual bool Foo2 => true;
+
+    [Throws(typeof(InvalidDataException))]
+    public virtual bool Foo3 { get; set; }
 }
 
 public class TestDerive : TestBase
@@ -72,7 +75,7 @@ public class TestDerive : TestBase
 
     public override bool Foo2
     {
-        [Throws(typeof(InvalidOperationException))]
-        get => true;
+        [Throws(typeof(ArgumentNullException))]
+        get => throw new ArgumentNullException();
     }
 }


### PR DESCRIPTION
These got worked on simultaneously while they are separate.

* Robustness of redundancy check - Handling of different syntax.
* Inheritance checks - Improve diagnostic messages