### PR TITLE
Improve redundancy analysis for try/catch #185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PR [#191](https://github.com/marinasundstrom/CheckedExceptions/pull/191) Add support for Glob patterns in ignore list
 
+- PR [#192](https://github.com/marinasundstrom/CheckedExceptions/pull/192) Improve redundancy analysis for try/catch
+
 ## [1.8.0] - 2025-07-31
 
 ### Added

--- a/CheckedExceptions.Tests/AnazylerConfigTest.cs
+++ b/CheckedExceptions.Tests/AnazylerConfigTest.cs
@@ -70,9 +70,12 @@ public partial class AnaylzerConfigTest
             }
             """;
 
-        var expected2 = Verifier.Informational("IOException")
+        var expected1 = Verifier.Informational("IOException")
             .WithSpan(9, 21, 9, 39);
 
-        await Verifier.VerifyAnalyzerAsync2(test, expected2);
+        var expected2 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantCatchAllClause)
+            .WithSpan(11, 9, 11, 14);
+
+        await Verifier.VerifyAnalyzerAsync2(test, expected1, expected2);
     }
 }

--- a/CheckedExceptions.Tests/BugFixes/BugFix185.cs
+++ b/CheckedExceptions.Tests/BugFixes/BugFix185.cs
@@ -1,0 +1,183 @@
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Sundstrom.CheckedExceptions.Tests.BugFixes;
+
+using Verifier = CSharpAnalyzerVerifier<CheckedExceptionsAnalyzer, DefaultVerifier>;
+
+public partial class Bugfix185
+{
+    [Fact]
+    public async Task Test()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class Test
+        {
+            [Throws(typeof(InvalidOperationException))]
+            public static void NewMethod()
+            {
+                try 
+                {
+                    throw new ArgumentException("");
+                }
+                catch(InvalidOperationException ex) 
+                {
+                    throw new InvalidOperationException();      
+                }
+            }
+        }
+        """;
+
+        var expected1 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("InvalidOperationException")
+            .WithSpan(5, 20, 5, 45);
+
+        var expected2 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdUnhandled)
+            .WithArguments("ArgumentException")
+            .WithSpan(10, 13, 10, 45);
+
+        await Verifier.VerifyAnalyzerAsync(test, opt =>
+        {
+            opt.ExpectedDiagnostics.AddRange(expected1, expected2);
+            opt.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+        });
+    }
+
+    [Fact]
+    public async Task Test_2()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class Test
+        {
+            [Throws(typeof(InvalidOperationException))]
+            public static void NewMethod()
+            {
+                try 
+                {
+                    throw new ArgumentException("");
+                }
+                catch(Exception ex) 
+                {
+                    throw new InvalidOperationException();      
+                }
+            }
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(test, opt =>
+        {
+            opt.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+        });
+    }
+
+    [Fact]
+    public async Task Test2()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class Test
+        {
+            [Throws(typeof(InvalidOperationException))]
+            public static void NewMethod()
+            {
+                try 
+                {
+                    throw new ArgumentException("");
+                }
+                catch 
+                {
+                    throw new InvalidOperationException();      
+                }
+            }
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(test, opt =>
+        {
+            opt.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+        });
+    }
+
+    [Fact]
+    public async Task Test3()
+    {
+        var test = /* lang=c#-test */ """
+        using System;
+
+        public class Test
+        {
+            [Throws(typeof(InvalidOperationException))]
+            public static void NewMethod()
+            {
+                try 
+                {
+
+                }
+                catch 
+                {
+                    throw new InvalidOperationException();      
+                }
+            }
+        }
+        """;
+
+        var expected1 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("InvalidOperationException")
+            .WithSpan(5, 20, 5, 45);
+
+        var expected2 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantCatchAllClause)
+            .WithSpan(12, 9, 12, 14);
+
+        await Verifier.VerifyAnalyzerAsync(test, opt =>
+        {
+            opt.ExpectedDiagnostics.AddRange(expected1, expected2);
+            opt.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+        });
+    }
+
+    [Fact]
+    public async Task Test4()
+    {
+        var test = /* lang=c#-test */ """
+            using System;
+
+            ReadAndParse();
+
+            [Throws(typeof(InvalidUserInputException))] // ✔️ Only the domain-specific exception is exposed
+            static int ReadAndParse()
+            {
+                string input = "abc";  // Simulated input — could be user input in real scenarios
+
+                try
+                {
+                    return int.Parse(input);
+                }
+                catch
+                {
+                    // Handle and rethrow as domain-specific exception
+                    throw new InvalidUserInputException("Input was not a valid number.", null);
+                }
+            }
+
+            class InvalidUserInputException : Exception
+            {
+                public InvalidUserInputException(string message, Exception inner)
+                    : base(message, inner) { }
+            }
+        """;
+
+        var expected = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdUnhandled)
+            .WithArguments("InvalidUserInputException")
+            .WithSpan(3, 5, 3, 19);
+
+        await Verifier.VerifyAnalyzerAsync(test, opt =>
+        {
+            opt.ExpectedDiagnostics.Add(expected);
+            opt.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
+        }, executable: true);
+    }
+}

--- a/CheckedExceptions/AnalyzerReleases.Unshipped.md
+++ b/CheckedExceptions/AnalyzerReleases.Unshipped.md
@@ -14,3 +14,4 @@ THROW009 | Usage   | Warning  | CheckedExceptionsAnalyzer
 THROW010 | Usage   | Error    | CheckedExceptionsAnalyzer
 THROW011 | Usage   | Warning  | CheckedExceptionsAnalyzer
 THROW012 | Usage   | Warning  | CheckedExceptionsAnalyzer
+THROW013 | Usage   | Warning  | CheckedExceptionsAnalyzer

--- a/Test/CheckedExceptions.settings.json
+++ b/Test/CheckedExceptions.settings.json
@@ -1,6 +1,10 @@
 {
     "disableXmlDocInterop": false,
-    "ignoredExceptions": [],
+    "ignoredExceptions": [
+        "System.*",
+        "!System.InvalidOperationException",
+        "!System.OverflowException"
+    ],
     "informationalExceptions": {
         "System.NotImplementedException": "Propagation",
         "System.IO.IOException": "Propagation",

--- a/Test/CheckedExceptions.settings.json
+++ b/Test/CheckedExceptions.settings.json
@@ -1,10 +1,6 @@
 {
     "disableXmlDocInterop": false,
-    "ignoredExceptions": [
-        "System.*",
-        "!System.InvalidOperationException",
-        "!System.OverflowException"
-    ],
+    "ignoredExceptions": [],
     "informationalExceptions": {
         "System.NotImplementedException": "Propagation",
         "System.IO.IOException": "Propagation",

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -1,29 +1,36 @@
-﻿using Test;
-
-
-try
+﻿try
 {
-    var httpClient = new HttpClient()
+    int result = ReadAndParse();
+    Console.WriteLine(result);
+}
+catch (InvalidUserInputException ex)
+{
+    Console.WriteLine($"Input error: {ex.Message}");
+}
+
+[Throws(typeof(InvalidUserInputException))] // ✔️ Only the domain-specific exception is exposed
+static int ReadAndParse()
+{
+    string input = "abc";  // Simulated input — could be user input in real scenarios
+
+    try
     {
-        BaseAddress = new Uri("https://www.scrapethissite.com")
-    };
-    var str = await httpClient.GetStringAsync("/");
-
-    Console.WriteLine(str);
+        return int.Parse(input);
+    }
+    catch (FormatException formatException)
+    {
+        // Handle and rethrow as domain-specific exception
+        throw new InvalidUserInputException("Input was not a valid number.", formatException);
+    }
+    catch (OverflowException overflowException)
+    {
+        // Handle and rethrow as domain-specific exception
+        throw new InvalidUserInputException("Input number was too large.", overflowException);
+    }
 }
-catch (InvalidOperationException)
-{
 
-}
-catch (HttpRequestException)
+class InvalidUserInputException : Exception
 {
-
-}
-catch (TaskCanceledException)
-{
-
-}
-catch (UriFormatException)
-{
-
+    public InvalidUserInputException(string message, Exception inner)
+        : base(message, inner) { }
 }


### PR DESCRIPTION
We add flow analysis that tells when exceptions are deemed redundant. It requires the most amount of information, like from XML doc.

Perhaps we can add option to turn off these analysis and diagnostics later.