### PR TITLE
Handle valid catches with no exceptions remaining #232

### DIFF
--- a/CheckedExceptions.CodeFixes/RemoveRedundantCatchClauseCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/RemoveRedundantCatchClauseCodeFixProvider.cs
@@ -19,7 +19,7 @@ public class RemoveRedundantCatchClauseCodeFixProvider : CodeFixProvider
     private const string TitleRemoveRedundantCatchClause = "Remove redundant catch clause";
 
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
-        [CheckedExceptionsAnalyzer.DiagnosticIdRedundantTypedCatchClause, CheckedExceptionsAnalyzer.DiagnosticIdRedundantCatchAllClause];
+        [CheckedExceptionsAnalyzer.DiagnosticIdRedundantTypedCatchClause, CheckedExceptionsAnalyzer.DiagnosticIdRedundantCatchAllClause, CheckedExceptionsAnalyzer.DiagnosticIdCatchHandlesNoRemainingExceptions];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
         WellKnownFixAllProviders.BatchFixer;

--- a/CheckedExceptions/AnalyzerReleases.Unshipped.md
+++ b/CheckedExceptions/AnalyzerReleases.Unshipped.md
@@ -15,5 +15,6 @@ THROW010 | Contract | Error | CheckedExceptionsAnalyzer
 THROW011 | Contract | Warning | CheckedExceptionsAnalyzer
 THROW012 | Contract | Warning | CheckedExceptionsAnalyzer
 THROW013 | Control flow | Warning | CheckedExceptionsAnalyzer
+THROW014 | Control flow | Warning | CheckedExceptionsAnalyzer
 THROW020 | Control flow | Warning | CheckedExceptionsAnalyzer
 IDE001 | Control flow | Hidden | CheckedExceptionsAnalyzer


### PR DESCRIPTION
Adding new diagnostic:

`All matching exceptions for this type are already caught by previous clauses ('InvalidUserInputException')` (`THROW014`)