### PR TITLE
Code fix removes "catch call" when redundant #249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- PR [#248](https://github.com/marinasundstrom/CheckedExceptions/pull/248) Code fix removes "catch call" when redundant
+
+### Fixed
+
 - PR [#247](https://github.com/marinasundstrom/CheckedExceptions/pull/247) Fix codefixes 
   - Fix "Add clause to existing try/catch" doesn't work [#244](https://github.com/marinasundstrom/CheckedExceptions/issues/244)
   - Fix "Surround with try/catch" doesn't work on statement in If Statement [#246](https://github.com/marinasundstrom/CheckedExceptions/issues/246)

--- a/CheckedExceptions.CodeFixes/AddCatchClauseToTryCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddCatchClauseToTryCodeFixProvider.cs
@@ -20,7 +20,7 @@ public class AddCatchClauseToTryCodeFixProvider : CodeFixProvider
         [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-        WellKnownFixAllProviders.BatchFixer;
+        null!;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.CodeFixes/AddThrowsDeclarationCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddThrowsDeclarationCodeFixProvider.cs
@@ -23,7 +23,7 @@ public class AddThrowsDeclarationCodeFixProvider : CodeFixProvider
         [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-        null!; //WellKnownFixAllProviders.BatchFixer;
+        WellKnownFixAllProviders.BatchFixer;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromBaseMemberCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromBaseMemberCodeFixProvider.cs
@@ -25,7 +25,7 @@ public class AddThrowsDeclarationFromBaseMemberCodeFixProvider : CodeFixProvider
         [CheckedExceptionsAnalyzer.DiagnosticIdMissingThrowsFromBaseMember];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-        null!; //WellKnownFixAllProviders.BatchFixer;
+        WellKnownFixAllProviders.BatchFixer;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromXmlDocCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromXmlDocCodeFixProvider.cs
@@ -25,7 +25,7 @@ public class AddThrowsDeclarationFromXmlDocCodeFixProvider : CodeFixProvider
         [CheckedExceptionsAnalyzer.DiagnosticIdXmlDocButNoThrows];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-        null!; //WellKnownFixAllProviders.BatchFixer;
+        WellKnownFixAllProviders.BatchFixer;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
@@ -130,8 +130,19 @@ public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixPr
 
             var catchClausesToAdd = CreateCatchClauses(newExceptionTypes, existingTryStatement.Catches.Count);
 
-            var newTry = existingTryStatement.WithCatches(existingTryStatement.Catches.InsertRange(existingTryStatement.Catches.Count - 1, catchClausesToAdd))
-                .WithAdditionalAnnotations(Formatter.Annotation);
+            TryStatementSyntax newTry;
+
+            if (statement.Parent is BlockSyntax block && block.Statements.Count == 1)
+            {
+                var catches = existingTryStatement.Catches.RemoveAt(existingTryStatement.Catches.Count - 1);
+                newTry = existingTryStatement.WithCatches(catches.AddRange(catchClausesToAdd))
+                                  .WithAdditionalAnnotations(Formatter.Annotation);
+            }
+            else
+            {
+                newTry = existingTryStatement.WithCatches(existingTryStatement.Catches.InsertRange(existingTryStatement.Catches.Count - 1, catchClausesToAdd))
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+            }
 
             if (newTry.Finally?.IsMissing ?? false)
             {

--- a/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
@@ -20,8 +20,8 @@ public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixPr
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
         [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
 
-    //public sealed override FixAllProvider GetFixAllProvider() =>
-    //    WellKnownFixAllProviders.BatchFixer;
+    public sealed override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
@@ -12,8 +12,8 @@ using static CatchClauseUtils;
 
 namespace Sundstrom.CheckedExceptions;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddCatchClauseForRethrownExceptionCodeFixProvider)), Shared]
-public class AddCatchClauseForRethrownExceptionCodeFixProvider : CodeFixProvider
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(IntroduceCatchClauseForRethrownExceptionCodeFixProvider)), Shared]
+public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixProvider
 {
     private const string TitleAddTryCatch = "Introduce catch clause";
 

--- a/CheckedExceptions.CodeFixes/SurroundWithTryCatchCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/SurroundWithTryCatchCodeFixProvider.cs
@@ -22,7 +22,7 @@ public class SurroundWithTryCatchCodeFixProvider : CodeFixProvider
         [CheckedExceptionsAnalyzer.DiagnosticIdUnhandled];
 
     public sealed override FixAllProvider GetFixAllProvider() =>
-        WellKnownFixAllProviders.BatchFixer;
+        null!;
 
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {

--- a/CheckedExceptions.Tests/CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProviderTests.cs
+++ b/CheckedExceptions.Tests/CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProviderTests.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, AddCatchClauseForRethrownExceptionCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using Verifier = CSharpCodeFixVerifier<CheckedExceptionsAnalyzer, IntroduceCatchClauseForRethrownExceptionCodeFixProvider, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
-public class AddCatchClauseForRethrownExceptionCodeFixProviderTests
+public class IntroduceCatchClauseForRethrownExceptionCodeFixProviderTests
 {
     [Fact]
     public async Task CatchAll_FixApplied()

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -17,7 +17,8 @@
   </PropertyGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Sundstrom.CheckedExceptions" Version="1.9.9">
+    <PackageReference Include="Sundstrom.CheckedExceptions" Version="1.9.9-*"
+      IncludePrerelease="true">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Other

* Renaming codefix classes
* Set `GetFixAllProvider()`
* Test project should use latest dev build