### PR TITLE
Fix LINQ boundary tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Warn about unhandled exceptions when LINQ queries are passed as arguments or returned from methods
+
 ## [2.1.1] - 2025-08-14
 
 ### Fixed

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
@@ -235,6 +235,13 @@ partial class CheckedExceptionsAnalyzer
                 {
                     var exceptionTypes = GetExceptionTypes(methodSymbol);
 
+                    if (settings.IsLinqSupportEnabled)
+                    {
+                        var exceptionTypeSet = new HashSet<INamedTypeSymbol>(exceptionTypes, SymbolEqualityComparer.Default);
+                        CollectLinqExceptions(invocation, exceptionTypeSet, compilation, semanticModel, settings);
+                        exceptionTypes = exceptionTypeSet.ToList();
+                    }
+
                     if (settings.IsXmlInteropEnabled)
                     {
                         // Get exceptions from XML documentation

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Linq.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Linq.cs
@@ -22,24 +22,54 @@ partial class CheckedExceptionsAnalyzer
         if (!IsLinqExtension(termOp.TargetMethod)) return;
 
         var name = termOp.TargetMethod.Name;
-        if (!LinqKnowledge.TerminalOps.Contains(name)) return;
+        var isTerminal = LinqKnowledge.TerminalOps.Contains(name);
 
-        // NEW: harvest predicate/selector on this terminal op
-        CollectThrowsFromFunctionalArguments(termOp, exceptionTypes, compilation, semanticModel, settings, ct);
+        // If this is neither a terminal operator nor crosses a boundary (argument/return), ignore
+        if (!isTerminal && !IsBoundary(termOp))
+            return;
 
-        // Existing: add built-ins for the terminal
-        if (LinqKnowledge.BuiltIns.TryGetValue(name, out var builtInFactory))
-            foreach (var t in builtInFactory(semanticModel.Compilation, termOp.TargetMethod))
-                if (t is not null) exceptionTypes.Add(t);
+        if (isTerminal)
+        {
+            // harvest predicate/selector on this terminal op
+            CollectThrowsFromFunctionalArguments(termOp, exceptionTypes, compilation, semanticModel, settings, ct);
 
-        // Backtrack upstream
-        var source = GetLinqSourceOperation(termOp);
-        if (source is null) return;
+            // add built-ins for the terminal
+            if (LinqKnowledge.BuiltIns.TryGetValue(name, out var builtInFactory))
+                foreach (var t in builtInFactory(semanticModel.Compilation, termOp.TargetMethod))
+                    if (t is not null) exceptionTypes.Add(t);
 
-        CollectDeferredChainExceptions(source, exceptionTypes, semanticModel.Compilation, semanticModel, settings);
+            // Backtrack upstream
+            var source = GetLinqSourceOperation(termOp);
+            if (source is null) return;
+
+            CollectDeferredChainExceptions(source, exceptionTypes, semanticModel.Compilation, semanticModel, settings);
+        }
+        else
+        {
+            // Deferred query passed across a boundary – collect upstream exceptions
+            CollectDeferredChainExceptions_ForEnumeration(termOp, exceptionTypes, compilation, semanticModel, settings, ct);
+        }
     }
 
     // --- helpers ---
+
+    private static bool IsBoundary(IOperation op)
+    {
+        for (var parent = op.Parent; parent is not null; parent = parent.Parent)
+        {
+            switch (parent)
+            {
+                case IArgumentOperation:
+                case IReturnOperation:
+                    return true;
+                case IConversionOperation or IParenthesizedOperation:
+                    continue;
+                default:
+                    return false;
+            }
+        }
+        return false;
+    }
 
     private static bool IsLinqExtension(IMethodSymbol method)
     {
@@ -94,7 +124,7 @@ partial class CheckedExceptionsAnalyzer
                     if (LinqKnowledge.TerminalOps.Contains(name))
                     {
                         // NEW: harvest lambdas/method groups on terminal op too
-                        CollectThrowsFromFunctionalArguments(inv, exceptionTypes, compilation, semanticModel, default);
+                        CollectThrowsFromFunctionalArguments(inv, exceptionTypes, compilation, semanticModel, settings, default);
 
                         if (LinqKnowledge.BuiltIns.TryGetValue(name, out var builtInFactory))
                             foreach (var t in builtInFactory(compilation, inv.TargetMethod))
@@ -105,7 +135,7 @@ partial class CheckedExceptionsAnalyzer
                     }
 
                     // Unknown op: still inspect functional args
-                    CollectThrowsFromFunctionalArguments(inv, exceptionTypes, compilation, semanticModel, default);
+                    CollectThrowsFromFunctionalArguments(inv, exceptionTypes, compilation, semanticModel, settings, default);
                     current = GetLinqSourceOperation(inv);
                     continue;
 


### PR DESCRIPTION
## Summary
- handle LINQ exception collection via a HashSet before enumeration
- update LINQ analyzer tests for deferred query boundaries and implicit diagnostics

## Testing
- `dotnet test CheckedExceptions.sln -v minimal`
- `dotnet format --no-restore -v diag` *(fails: Msbuild failed when processing the file '/workspace/CheckedExceptions/CheckedExceptions/CheckedExceptions.csproj')*

------
https://chatgpt.com/codex/tasks/task_e_68a812bb52dc832f99a68261b2729f6a