### PR TITLE
Skip THROW017 for materialized LINQ enumerables

### DIFF
--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -258,9 +258,17 @@ public partial class LinqTest
         var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(9, 15, 9, 24);
 
+        var expected3 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdImplicitlyDeclaredException)
+            .WithArguments("FormatException")
+            .WithSpan(8, 34, 8, 42);
+
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdImplicitlyDeclaredException)
+            .WithArguments("OverflowException")
+            .WithSpan(8, 34, 8, 42);
+
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
-            o.ExpectedDiagnostics.AddRange(expected, expected2);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4);
         }, executable: true);
     }
 
@@ -284,9 +292,17 @@ public partial class LinqTest
         var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(8, 24, 8, 33);
 
+        var expected3 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdImplicitlyDeclaredException)
+            .WithArguments("FormatException")
+            .WithSpan(7, 34, 7, 42);
+
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdImplicitlyDeclaredException)
+            .WithArguments("OverflowException")
+            .WithSpan(7, 34, 7, 42);
+
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
-            //o.ExpectedDiagnostics.AddRange(expected, expected2);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4);
         }, executable: true);
     }
 

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -286,6 +286,16 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         if (argumentSyntax.Expression is null)
             return;
 
+        // If the argument materializes the sequence (e.g., ToArray()),
+        // the invocation analysis will handle diagnostics. Skip boundary reporting.
+        if (argumentSyntax.Expression is InvocationExpressionSyntax invSyntax &&
+            semanticModel.GetOperation(invSyntax) is IInvocationOperation invOp &&
+            IsLinqExtension(invOp.TargetMethod) &&
+            LinqKnowledge.TerminalOps.Contains(invOp.TargetMethod.Name))
+        {
+            return;
+        }
+
         // Collect exceptions that will surface when enumeration happens
         var exceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 

--- a/Test/LinqTest.cs
+++ b/Test/LinqTest.cs
@@ -138,5 +138,6 @@ public class LinqTest
         IEnumerable<string> items = [];
         var query = items.Where(x => int.Parse(x) > 0);
         foreach (var i in query.ToArray()) { }
+        return new int[0];
     }
 }


### PR DESCRIPTION
## Summary
- avoid reporting THROW017 when deferred sequences are materialized before crossing boundaries
- handle terminal LINQ invocations inside arguments
- cover materialized enumerable scenarios with tests

## Testing
- `dotnet build CheckedExceptions.sln`
- `dotnet test CheckedExceptions.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb92e610832f9e55533d3c922394