### PR TITLE
Mark redundant exception declarations in LINQ #274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PR [#287](https://github.com/marinasundstrom/CheckedExceptions/pull/287) Fix LINQ chain diagnostics
 - PR [#294](https://github.com/marinasundstrom/CheckedExceptions/pull/294) Enable batch fixing for catch-clause, try-catch, and redundant catch clause code fixes
+- PR [#293](https://github.com/marinasundstrom/CheckedExceptions/pull/293) Mark throws declarations in LINQ lambdas as redundant when implicitly declared exceptions are enabled
 
 ## [2.1.2] - 2025-08-22
 

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -31,9 +31,18 @@ public partial class LinqTest
         var expected3 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(8, 15, 8, 22);
 
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("FormatException")
+            .WithSpan(7, 40, 7, 55);
+
+        var expected5 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("OverflowException")
+            .WithSpan(7, 65, 7, 82);
+
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
-            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4, expected5);
+            o.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
         }, executable: true);
     }
 
@@ -61,10 +70,19 @@ public partial class LinqTest
         var expected3 = Verifier.UnhandledException("InvalidOperationException")
             .WithSpan(9, 21, 9, 33);
 
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("FormatException")
+            .WithSpan(8, 40, 8, 55);
+
+        var expected5 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("OverflowException")
+            .WithSpan(8, 65, 8, 82);
+
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
             o.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(System.Linq.AsyncEnumerable).Assembly.Location));
-            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4, expected5);
+            o.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
         }, executable: true);
     }
 
@@ -127,10 +145,18 @@ public partial class LinqTest
 
         var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(8, 22, 8, 27);
+        var expected3 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("FormatException")
+            .WithSpan(7, 40, 7, 55);
+
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("OverflowException")
+            .WithSpan(7, 65, 7, 82);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
-            o.ExpectedDiagnostics.AddRange(expected, expected2);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4);
+            o.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
         }, executable: true);
     }
 
@@ -154,7 +180,6 @@ public partial class LinqTest
 
         var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(9, 22, 9, 27);
-
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
             o.ExpectedDiagnostics.AddRange(expected, expected2);
@@ -181,7 +206,6 @@ public partial class LinqTest
 
         var expected2 = Verifier.UnhandledException("OverflowException")
             .WithSpan(9, 22, 9, 27);
-
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
             o.ExpectedDiagnostics.AddRange(expected, expected2);
@@ -213,10 +237,18 @@ public partial class LinqTest
 
         var expected3 = Verifier.UnhandledException("InvalidCastException")
             .WithSpan(11, 22, 11, 27);
+        var expected4 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("FormatException")
+            .WithSpan(8, 27, 8, 42);
+
+        var expected5 = Verifier.Diagnostic(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration)
+            .WithArguments("OverflowException")
+            .WithSpan(8, 52, 8, 69);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
-            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3);
+            o.ExpectedDiagnostics.AddRange(expected, expected2, expected3, expected4, expected5);
+            o.DisabledDiagnostics.Remove(CheckedExceptionsAnalyzer.DiagnosticIdRedundantExceptionDeclaration);
         }, executable: true);
     }
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Add `CheckedExceptions.settings.json`:
   // If true, analysis on LINQ constructs will be disabled (default: false).
   "disableLinqSupport": false,
 
-  // If true, exceptions in LINQ lambdas do not have to be declared (default: false).
+  // If true, implicit exception inference in LINQ lambdas is disabled and declarations are required (default: false).
   "disableLinqImplicitlyDeclaredExceptions": false,
 
   // If true, no diagnostics will be issued on contract boundaries, such as arguments to methods and  return statements (default: false).
@@ -317,7 +317,7 @@ var tens = values
     .ToArray(); // THROW001: unhandled FormatException, OverflowException
 ```
 
-> Exceptions are inferred and implicit on LINQ methods, so no declarations needed. this behavior can be disabled. 
+> Exceptions are inferred and implicit on LINQ methods. Any explicit `[Throws]` on LINQ lambdas is flagged as redundant. This behavior can be disabled.
 
 Read about it [here](docs/linq-support.md).
 

--- a/docs/analyzer-specification.md
+++ b/docs/analyzer-specification.md
@@ -503,7 +503,7 @@ This option disables analysis of LINQ operators defined on `Queryable`. Expressi
 
 #### Disable implicitly declared exceptions in lambdas
 
-This option control whether to disable implicitly declared exceptions in lambdas passed into LINQ operator methods.
+This option controls whether to disable implicitly declared exceptions in lambdas passed into LINQ operator methods. When enabled (the default), exceptions are inferred and any `[Throws]` declarations on these lambdas are reported as redundant.
 
 ```json
 {

--- a/docs/linq-support.md
+++ b/docs/linq-support.md
@@ -26,7 +26,7 @@ var allEven = values
 // THROW001: Unhandled exception type 'OverflowException'
 ```
 
-> Exceptions are inferred and implicit on LINQ methods, so no declarations needed. this behavior can be disabled. 
+> Exceptions are inferred and implicit on LINQ methods. Any explicit `[Throws]` on LINQ lambdas is reported as redundant. This behavior can be disabled.
 
 This differs from `First()`/`Single()` cases by not adding its own “empty/duplicate” errors—`All` only reflects exceptions from the predicate.
 


### PR DESCRIPTION
## Summary
- flag `Throws` declarations in LINQ lambdas as redundant when implicit exceptions are enabled
- document redundant `Throws` declarations for LINQ lambdas
- add tests for redundant `Throws` in LINQ queries

## Testing
- `dotnet format CheckedExceptions.sln --no-restore --include CheckedExceptions/CheckedExceptionsAnalyzer.ControlFlow.cs,README.md,docs/analyzer-specification.md,docs/linq-support.md,CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs,CHANGELOG.md --verbosity diagnostic`
- `dotnet test CheckedExceptions.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a9a6cac84c832f9b0a0998b70058d4