### PR TITLE
Handle updated nodes in batch code fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- PR [#PR_NUMBER](https://github.com/marinasundstrom/CheckedExceptions/pull/PR_NUMBER) Fetch updated syntax nodes in code fixes to ensure batch fixes apply correctly
+
 ## [2.2.1] - 2025-08-23
 
 ### Added

--- a/CheckedExceptions.CodeFixes/AddCatchClauseToTryCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddCatchClauseToTryCodeFixProvider.cs
@@ -69,7 +69,7 @@ public class AddCatchClauseToTryCodeFixProvider : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: diagnosticsCount > 1 ? TitleAddTryCatch.Replace("clause", "clauses") : TitleAddTryCatch,
-                createChangedDocument: c => AddTryCatchAsync(context.Document, (StatementSyntax)throwSite!, diagnostics, c),
+                createChangedDocument: c => AddTryCatchAsync(context.Document, diagnostics, c),
                 equivalenceKey: TitleAddTryCatch),
             diagnostics);
     }
@@ -80,7 +80,7 @@ public class AddCatchClauseToTryCodeFixProvider : CodeFixProvider
             ?? node.FirstAncestorOrSelf<LocalFunctionStatementSyntax>();
     }
 
-    private async Task<Document> AddTryCatchAsync(Document document, StatementSyntax statement, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    private async Task<Document> AddTryCatchAsync(Document document, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         // Retrieve exception types from diagnostics
         var exceptionTypeNames = diagnostics
@@ -92,6 +92,10 @@ public class AddCatchClauseToTryCodeFixProvider : CodeFixProvider
         {
             return document;
         }
+
+        var diagnostic = diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+        var statement = (StatementSyntax)(node is ExpressionSyntax expr ? expr.FirstAncestorOrSelf<StatementSyntax>()! : node);
 
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 

--- a/CheckedExceptions.CodeFixes/AddThrowsDeclarationCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddThrowsDeclarationCodeFixProvider.cs
@@ -44,17 +44,19 @@ public class AddThrowsDeclarationCodeFixProvider : CodeFixProvider
         context.RegisterCodeFix(
         CodeAction.Create(
             title: diagnosticsCount > 1 ? TitleAddThrowsAttribute.Replace("declaration", "declarations") : TitleAddThrowsAttribute,
-            createChangedDocument: c => AddThrowsAttributeAsync(context.Document, node, diagnostics, c),
+            createChangedDocument: c => AddThrowsAttributeAsync(context.Document, diagnostics, c),
             equivalenceKey: TitleAddThrowsAttribute),
         diagnostics);
     }
 
-    private async Task<Document> AddThrowsAttributeAsync(Document document, SyntaxNode node, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    private async Task<Document> AddThrowsAttributeAsync(Document document, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         // Attempt to retrieve the exception type from diagnostic arguments
         var exceptionTypeNames = diagnostics.Select(diagnostic => diagnostic.Properties["ExceptionType"]);
 
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        var node = root.FindNode(diagnostics.First().Location.SourceSpan);
 
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 

--- a/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromBaseMemberCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/AddThrowsDeclarationFromBaseMemberCodeFixProvider.cs
@@ -68,14 +68,42 @@ public class AddThrowsDeclarationFromBaseMemberCodeFixProvider : CodeFixProvider
                 title: diagnosticsCount > 1
                     ? Title.Replace("declaration", "declarations")
                     : Title,
-                createChangedDocument: c => ApplyCodefix(context.Document, targetNode, diagnostics, c),
+                createChangedDocument: c => ApplyCodefix(context.Document, diagnostics, c),
                 equivalenceKey: Title),
             diagnostics);
     }
 
-    private static async Task<Document> ApplyCodefix(Document document, SyntaxNode targetNode, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyCodefix(Document document, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root is null)
+            return document;
+
+        var node = root.FindNode(diagnostics.First().Location.SourceSpan);
+
+        SyntaxNode? targetNode = null;
+
+        if (node is GlobalStatementSyntax globalStatement)
+        {
+            targetNode = globalStatement.Statement as LocalFunctionStatementSyntax;
+        }
+        else if (node is PropertyDeclarationSyntax propertyDeclaration)
+        {
+            targetNode = propertyDeclaration;
+        }
+        else if (node is AccessorDeclarationSyntax accessorDeclaration)
+        {
+            targetNode = accessorDeclaration;
+        }
+        else
+        {
+            targetNode = (SyntaxNode?)node.FirstAncestorOrSelf<LocalFunctionStatementSyntax>()
+                ?? node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+        }
+
+        if (targetNode is null)
+            return document;
 
         // Collect exception type names from diagnostics
         var exceptionsToAdd = diagnostics

--- a/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs
@@ -81,7 +81,7 @@ public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixPr
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: diagnosticsCount > 1 ? TitleAddTryCatch.Replace("clause", "clauses") : TitleAddTryCatch,
-                createChangedDocument: c => AddTryCatchAsync(context.Document, (StatementSyntax)throwSite!, diagnostics, c),
+                createChangedDocument: c => AddTryCatchAsync(context.Document, diagnostics, c),
                 equivalenceKey: TitleAddTryCatch),
             diagnostics);
     }
@@ -92,7 +92,7 @@ public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixPr
             ?? node.FirstAncestorOrSelf<LocalFunctionStatementSyntax>();
     }
 
-    private async Task<Document> AddTryCatchAsync(Document document, StatementSyntax statement, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
+    private async Task<Document> AddTryCatchAsync(Document document, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         // Retrieve exception types from diagnostics
         var exceptionTypeNames = diagnostics
@@ -104,6 +104,10 @@ public class IntroduceCatchClauseForRethrownExceptionCodeFixProvider : CodeFixPr
         {
             return document;
         }
+
+        var diagnostic = diagnostics.First();
+        var node = root.FindNode(diagnostic.Location.SourceSpan);
+        var statement = (StatementSyntax)(node is ExpressionSyntax expr ? expr.FirstAncestorOrSelf<StatementSyntax>()! : node);
 
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 

--- a/CheckedExceptions.CodeFixes/MaterializeEnumerableCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/MaterializeEnumerableCodeFixProvider.cs
@@ -33,15 +33,19 @@ public class MaterializeEnumerableCodeFixProvider : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 Title,
-                c => AddToArrayAsync(context.Document, node, c),
+                c => AddToArrayAsync(context.Document, diagnostic, c),
                 Title),
             context.Diagnostics);
     }
 
-    private static async Task<Document> AddToArrayAsync(Document document, ExpressionSyntax expression, CancellationToken cancellationToken)
+    private static async Task<Document> AddToArrayAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) as CompilationUnitSyntax;
         if (root is null)
+            return document;
+
+        var expression = root.FindNode(diagnostic.Location.SourceSpan) as ExpressionSyntax;
+        if (expression is null)
             return document;
 
         var exprWithoutTrivia = expression.WithoutTrivia();

--- a/CheckedExceptions.CodeFixes/RemoveRedundantExceptionDeclarationCodeFixProvider.cs
+++ b/CheckedExceptions.CodeFixes/RemoveRedundantExceptionDeclarationCodeFixProvider.cs
@@ -37,14 +37,18 @@ public class RemoveRedundantExceptionDeclarationCodeFixProvider : CodeFixProvide
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: TitleRemoveRedundantExceptionDeclaration,
-                createChangedDocument: c => RemoveRedundantDeclarationAsync(context.Document, argument, c),
+                createChangedDocument: c => RemoveRedundantDeclarationAsync(context.Document, diagnostic, c),
                 equivalenceKey: TitleRemoveRedundantExceptionDeclaration),
             context.Diagnostics);
     }
 
-    private static async Task<Document> RemoveRedundantDeclarationAsync(Document document, AttributeArgumentSyntax argument, CancellationToken cancellationToken)
+    private static async Task<Document> RemoveRedundantDeclarationAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var argument = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<AttributeArgumentSyntax>();
+        if (argument is null)
+            return document;
 
         var attribute = (AttributeSyntax)argument.Parent.Parent;
         var list = (AttributeListSyntax)attribute.Parent;


### PR DESCRIPTION
## Summary
- refetch syntax nodes inside code fix methods so batch fixes apply to updated documents
- rework code fix registration to only perform applicability checks and fetch fresh nodes during execution

## Testing
- `dotnet format CheckedExceptions.sln --no-restore --include CheckedExceptions.CodeFixes/AddCatchClauseToTryCodeFixProvider.cs,CheckedExceptions.CodeFixes/AddThrowsDeclarationCodeFixProvider.cs,CheckedExceptions.CodeFixes/AddThrowsDeclarationFromBaseMemberCodeFixProvider.cs,CheckedExceptions.CodeFixes/AddThrowsDeclarationFromXmlDocCodeFixProvider.cs,CheckedExceptions.CodeFixes/IntroduceCatchClauseForRethrownExceptionCodeFixProvider.cs,CheckedExceptions.CodeFixes/MaterializeEnumerableCodeFixProvider.cs,CheckedExceptions.CodeFixes/RemoveRedundantExceptionDeclarationCodeFixProvider.cs,CheckedExceptions.CodeFixes/SurroundWithTryCatchCodeFixProvider.cs --verbosity diagnostic`
- `dotnet build CheckedExceptions.sln`
- `dotnet test CheckedExceptions.sln`


------
https://chatgpt.com/codex/tasks/task_e_68aabf2565a4832fb09dfb80811efb3b