### PR TITLE
Handle spread enumeration in collection expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- PR [#PR_NUMBER](https://github.com/marinasundstrom/CheckedExceptions/pull/PR_NUMBER) Report LINQ exceptions for spread elements in collection expressions
+
 ## [2.2.2] - 2025-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- PR [#PR_NUMBER](https://github.com/marinasundstrom/CheckedExceptions/pull/PR_NUMBER) Report LINQ exceptions for spread elements in collection expressions
+- PR [#298](https://github.com/marinasundstrom/CheckedExceptions/pull/298) Report LINQ exceptions for spread elements in collection expressions
 
 ## [2.2.2] - 2025-08-24
 

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -408,7 +408,7 @@ public partial class LinqTest
             """;
 
         var expected = Verifier.UnhandledException("InvalidCastException")
-            .WithSpan(10, 12, 10, 19);
+            .WithSpan(10, 13, 10, 18);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
@@ -435,7 +435,7 @@ public partial class LinqTest
             """;
 
         var expected = Verifier.UnhandledException("InvalidCastException")
-            .WithSpan(10, 12, 10, 19);
+            .WithSpan(10, 29, 10, 34);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -391,6 +391,32 @@ public partial class LinqTest
     }
 
     [Fact]
+    public async Task SpreadMaterializesQuery()
+    {
+        var test = /* lang=c#-test */ """
+            #nullable enable
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            IEnumerable<int> Cast4()
+            {
+                IEnumerable<object> xs2 = [];
+                var q0 = xs2.Where(x => x is not null).Cast<int>();
+                return [.. q0];
+            }
+            """;
+
+        var expected = Verifier.UnhandledException("InvalidCastException")
+            .WithSpan(10, 12, 10, 19);
+
+        await Verifier.VerifyAnalyzerAsync(test, setup: o =>
+        {
+            o.ExpectedDiagnostics.Add(expected);
+        }, executable: true);
+    }
+
+    [Fact]
     public async Task ReturnQuery()
     {
         var test = /* lang=c#-test */ """

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -417,6 +417,33 @@ public partial class LinqTest
     }
 
     [Fact]
+    public async Task Spread()
+    {
+        var test = /* lang=c#-test */ """
+            #nullable enable
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            IEnumerable<int> Cast4()
+            {
+                IEnumerable<object> xs2 = [];
+                var q0 = xs2.Where(x => x is not null).Cast<int>();
+                IEnumerable<int> foo = [.. q0];
+                return foo;
+            }
+            """;
+
+        var expected = Verifier.UnhandledException("InvalidCastException")
+            .WithSpan(10, 12, 10, 19);
+
+        await Verifier.VerifyAnalyzerAsync(test, setup: o =>
+        {
+            o.ExpectedDiagnostics.Add(expected);
+        }, executable: true);
+    }
+
+    [Fact]
     public async Task ReturnQuery()
     {
         var test = /* lang=c#-test */ """

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
@@ -371,10 +371,13 @@ partial class CheckedExceptionsAnalyzer
         var collectionExpressions = expression.DescendantNodesAndSelf().OfType<CollectionExpressionSyntax>();
         foreach (var collectionExpr in collectionExpressions)
         {
-            var op = semanticModel.GetOperation(collectionExpr);
-            if (op is not null)
+            foreach (var spread in collectionExpr.Elements.OfType<SpreadElementSyntax>())
             {
-                CollectEnumerationExceptions(op, exceptions, compilation, semanticModel, settings, default);
+                var op = semanticModel.GetOperation(spread.Expression);
+                if (op is not null)
+                {
+                    CollectEnumerationExceptions(op, exceptions, compilation, semanticModel, settings, default);
+                }
             }
         }
     }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Analysis.cs
@@ -367,6 +367,16 @@ partial class CheckedExceptionsAnalyzer
                 }
             }
         }
+
+        var collectionExpressions = expression.DescendantNodesAndSelf().OfType<CollectionExpressionSyntax>();
+        foreach (var collectionExpr in collectionExpressions)
+        {
+            var op = semanticModel.GetOperation(collectionExpr);
+            if (op is not null)
+            {
+                CollectEnumerationExceptions(op, exceptions, compilation, semanticModel, settings, default);
+            }
+        }
     }
 
     private static HashSet<INamedTypeSymbol>? GetCaughtExceptions(SyntaxList<CatchClauseSyntax> catchClauses, SemanticModel semanticModel)

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.Linq.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.Linq.cs
@@ -333,21 +333,7 @@ partial class CheckedExceptionsAnalyzer
             break;
         }
 
-        if (inner is ICollectionExpressionOperation collExpr && collExpr.Syntax is CollectionExpressionSyntax ces)
-        {
-            foreach (var element in ces.Elements)
-            {
-                if (element is SpreadElementSyntax spreadSyntax)
-                {
-                    var spreadOp = semanticModel.GetOperation(spreadSyntax.Expression, ct);
-                    if (spreadOp is not null)
-                    {
-                        CollectEnumerationExceptions(spreadOp, exceptionTypes, compilation, semanticModel, settings, ct);
-                    }
-                }
-            }
-            return;
-        }
+        // Collection expression spread elements are handled by callers.
 
         if (inner is IInvocationOperation inv &&
             IsLinqExtension(inv.TargetMethod, settings) &&

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -377,26 +377,6 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         if (returnStatementSyntax.Expression is CollectionExpressionSyntax coll &&
             coll.Elements.Any(e => e is SpreadElementSyntax))
         {
-            var spreadExceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-            foreach (var spread in coll.Elements.OfType<SpreadElementSyntax>())
-            {
-                var spreadOp = semanticModel.GetOperation(spread.Expression, context.CancellationToken);
-                if (spreadOp is not null)
-                {
-                    CollectEnumerationExceptions(spreadOp, spreadExceptionTypes, context.Compilation, semanticModel, settings, context.CancellationToken);
-                }
-            }
-
-            spreadExceptionTypes = new HashSet<INamedTypeSymbol>(
-                ProcessNullable(context.Compilation, context.SemanticModel, returnStatementSyntax.Expression, null, spreadExceptionTypes),
-                SymbolEqualityComparer.Default);
-
-            foreach (var t in spreadExceptionTypes.Distinct(SymbolEqualityComparer.Default))
-            {
-                AnalyzeExceptionThrowingNode(context, returnStatementSyntax.Expression, (INamedTypeSymbol)t!, settings);
-            }
-
             return;
         }
 

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -260,6 +260,39 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(AnalyzeForeachStatement, SyntaxKind.ForEachStatement);
         context.RegisterSyntaxNodeAction(AnalyzeReturnStatement, SyntaxKind.ReturnStatement);
         context.RegisterSyntaxNodeAction(AnalyzeArgument, SyntaxKind.Argument);
+        context.RegisterSyntaxNodeAction(AnalyzeSpreadElement, SyntaxKind.SpreadElement);
+    }
+
+    private void AnalyzeSpreadElement(SyntaxNodeAnalysisContext context)
+    {
+        var spreadSyntax = (SpreadElementSyntax)context.Node;
+
+        var settings = GetAnalyzerSettings(context.Options);
+
+        if (!settings.IsLinqSupportEnabled)
+            return;
+
+        if (!settings.IsLinqEnumerableBoundaryWarningsEnabled)
+            return;
+
+        var semanticModel = context.SemanticModel;
+
+        var spreadOp = semanticModel.GetOperation(spreadSyntax.Expression, context.CancellationToken);
+        if (spreadOp is null)
+            return;
+
+        var exceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        CollectEnumerationExceptions(spreadOp, exceptionTypes, context.Compilation, semanticModel, settings, context.CancellationToken);
+
+        exceptionTypes = new HashSet<INamedTypeSymbol>(
+            ProcessNullable(context.Compilation, semanticModel, spreadSyntax.Expression, null, exceptionTypes),
+            SymbolEqualityComparer.Default);
+
+        foreach (var t in exceptionTypes.Distinct(SymbolEqualityComparer.Default))
+        {
+            AnalyzeExceptionThrowingNode(context, spreadSyntax, (INamedTypeSymbol?)t, settings);
+        }
     }
 
     private void AnalyzeArgument(SyntaxNodeAnalysisContext context)
@@ -285,6 +318,12 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
         if (argumentSyntax.Expression is null)
             return;
+
+        if (argumentSyntax.Expression is CollectionExpressionSyntax coll &&
+            coll.Elements.Any(e => e is SpreadElementSyntax))
+        {
+            return;
+        }
 
         // If the argument materializes the sequence (e.g., ToArray()),
         // the invocation analysis will handle diagnostics. Skip boundary reporting.
@@ -338,19 +377,6 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         if (returnStatementSyntax.Expression is CollectionExpressionSyntax coll &&
             coll.Elements.Any(e => e is SpreadElementSyntax))
         {
-            var spreadExceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-            CollectEnumerationExceptions(returnOp.ReturnedValue, spreadExceptionTypes, context.Compilation, semanticModel, settings, context.CancellationToken);
-
-            spreadExceptionTypes = new HashSet<INamedTypeSymbol>(
-                ProcessNullable(context.Compilation, context.SemanticModel, returnStatementSyntax.Expression, null, spreadExceptionTypes),
-                SymbolEqualityComparer.Default);
-
-            foreach (var t in spreadExceptionTypes.Distinct(SymbolEqualityComparer.Default))
-            {
-                AnalyzeExceptionThrowingNode(context, returnStatementSyntax.Expression, (INamedTypeSymbol)t!, settings);
-            }
-
             return;
         }
 
@@ -403,6 +429,12 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         var op = semanticModel.GetOperation(forEachSyntax);
         if (op is not IForEachLoopOperation forEachOp)
             return;
+
+        if (forEachSyntax.Expression is CollectionExpressionSyntax coll &&
+            coll.Elements.Any(e => e is SpreadElementSyntax))
+        {
+            return;
+        }
 
         // Collect exceptions that will surface when enumeration happens
         var exceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);


### PR DESCRIPTION
## Summary
- handle LINQ exceptions from spread elements in collection expressions
- test spread elements materialize deferred LINQ queries

## Testing
- `dotnet test CheckedExceptions.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aad4288578832f90bb4c85c67775bf