### PR TITLE
Handle LINQ exceptions in spread elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- PR [#PR_NUMBER](https://github.com/marinasundstrom/CheckedExceptions/pull/PR_NUMBER) Report LINQ exceptions for spread elements in collection expressions
+- PR [#298](https://github.com/marinasundstrom/CheckedExceptions/pull/298) Report LINQ exceptions for spread elements in collection expressions
 
 ## [2.2.2] - 2025-08-24
 

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs
@@ -408,7 +408,7 @@ public partial class LinqTest
             """;
 
         var expected = Verifier.UnhandledException("InvalidCastException")
-            .WithSpan(10, 12, 10, 19);
+            .WithSpan(10, 13, 10, 18);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {
@@ -435,7 +435,7 @@ public partial class LinqTest
             """;
 
         var expected = Verifier.UnhandledException("InvalidCastException")
-            .WithSpan(10, 12, 10, 19);
+            .WithSpan(10, 29, 10, 34);
 
         await Verifier.VerifyAnalyzerAsync(test, setup: o =>
         {

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.cs
@@ -260,6 +260,39 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(AnalyzeForeachStatement, SyntaxKind.ForEachStatement);
         context.RegisterSyntaxNodeAction(AnalyzeReturnStatement, SyntaxKind.ReturnStatement);
         context.RegisterSyntaxNodeAction(AnalyzeArgument, SyntaxKind.Argument);
+        context.RegisterSyntaxNodeAction(AnalyzeSpreadElement, SyntaxKind.SpreadElement);
+    }
+
+    private void AnalyzeSpreadElement(SyntaxNodeAnalysisContext context)
+    {
+        var spreadSyntax = (SpreadElementSyntax)context.Node;
+
+        var settings = GetAnalyzerSettings(context.Options);
+
+        if (!settings.IsLinqSupportEnabled)
+            return;
+
+        if (!settings.IsLinqEnumerableBoundaryWarningsEnabled)
+            return;
+
+        var semanticModel = context.SemanticModel;
+
+        var spreadOp = semanticModel.GetOperation(spreadSyntax.Expression, context.CancellationToken);
+        if (spreadOp is null)
+            return;
+
+        var exceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        CollectEnumerationExceptions(spreadOp, exceptionTypes, context.Compilation, semanticModel, settings, context.CancellationToken);
+
+        exceptionTypes = new HashSet<INamedTypeSymbol>(
+            ProcessNullable(context.Compilation, semanticModel, spreadSyntax.Expression, null, exceptionTypes),
+            SymbolEqualityComparer.Default);
+
+        foreach (var t in exceptionTypes.Distinct(SymbolEqualityComparer.Default))
+        {
+            AnalyzeExceptionThrowingNode(context, spreadSyntax, (INamedTypeSymbol?)t, settings);
+        }
     }
 
     private void AnalyzeArgument(SyntaxNodeAnalysisContext context)
@@ -285,6 +318,12 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
 
         if (argumentSyntax.Expression is null)
             return;
+
+        if (argumentSyntax.Expression is CollectionExpressionSyntax coll &&
+            coll.Elements.Any(e => e is SpreadElementSyntax))
+        {
+            return;
+        }
 
         // If the argument materializes the sequence (e.g., ToArray()),
         // the invocation analysis will handle diagnostics. Skip boundary reporting.
@@ -338,19 +377,6 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         if (returnStatementSyntax.Expression is CollectionExpressionSyntax coll &&
             coll.Elements.Any(e => e is SpreadElementSyntax))
         {
-            var spreadExceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-            CollectEnumerationExceptions(returnOp.ReturnedValue, spreadExceptionTypes, context.Compilation, semanticModel, settings, context.CancellationToken);
-
-            spreadExceptionTypes = new HashSet<INamedTypeSymbol>(
-                ProcessNullable(context.Compilation, context.SemanticModel, returnStatementSyntax.Expression, null, spreadExceptionTypes),
-                SymbolEqualityComparer.Default);
-
-            foreach (var t in spreadExceptionTypes.Distinct(SymbolEqualityComparer.Default))
-            {
-                AnalyzeExceptionThrowingNode(context, returnStatementSyntax.Expression, (INamedTypeSymbol)t!, settings);
-            }
-
             return;
         }
 
@@ -403,6 +429,12 @@ public partial class CheckedExceptionsAnalyzer : DiagnosticAnalyzer
         var op = semanticModel.GetOperation(forEachSyntax);
         if (op is not IForEachLoopOperation forEachOp)
             return;
+
+        if (forEachSyntax.Expression is CollectionExpressionSyntax coll &&
+            coll.Elements.Any(e => e is SpreadElementSyntax))
+        {
+            return;
+        }
 
         // Collect exceptions that will surface when enumeration happens
         var exceptionTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);


### PR DESCRIPTION
## Summary
- flag exceptions from LINQ queries used in spread elements
- avoid boundary diagnostics for collection expressions that enumerate immediately
- tighten tests for spread element handling

## Testing
- `dotnet format CheckedExceptions.sln --no-restore --include CheckedExceptions/CheckedExceptionsAnalyzer.cs,CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.Linq.cs,CHANGELOG.md`
- `dotnet test CheckedExceptions.sln`

------
https://chatgpt.com/codex/tasks/task_e_68aae600c874832f8e2a88fad2f68f79