### PR TITLE
feat: allow Exception declaration as catch-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- PR [#301](https://github.com/marinasundstrom/CheckedExceptions/pull/301) Allow treating `Exception` in `[Throws]` as a catch-all via `treatThrowsExceptionAsCatchRest` setting
+
 ## [2.2.3] - 2025-08-24
 
 ### Fixed

--- a/CheckedExceptions.Tests/CheckedExceptions.settings.json
+++ b/CheckedExceptions.Tests/CheckedExceptions.settings.json
@@ -12,6 +12,7 @@
     "disableLinqImplicitlyDeclaredExceptions": false,
     "disableControlFlowAnalysis": false,
     "enableLegacyRedundancyChecks": false,
+    "treatThrowsExceptionAsCatchRest": false,
     "disableBaseExceptionDeclaredDiagnostic": false,
     "disableBaseExceptionThrownDiagnostic": false
 }

--- a/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.ThrowsExceptionCatchRest.cs
+++ b/CheckedExceptions.Tests/CheckedExceptionsAnalyzerTests.ThrowsExceptionCatchRest.cs
@@ -1,0 +1,59 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Sundstrom.CheckedExceptions.Tests;
+
+using Verifier = CSharpAnalyzerVerifier<CheckedExceptionsAnalyzer, DefaultVerifier>;
+
+public partial class CheckedExceptionsAnalyzerTests
+{
+    [Fact]
+    public async Task DeclaringExceptionWithSpecific_ShouldReportRedundantDiagnosticByDefault()
+    {
+        var test = /* lang=c#-test */ """
+            using System;
+
+            public class TestClass
+            {
+                [Throws(typeof(InvalidOperationException), typeof(Exception))]
+                public void TestMethod()
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            """;
+
+        var expectedRedundant = Verifier.RedundantExceptionDeclarationBySuperType("Exception")
+            .WithSpan(5, 20, 5, 45);
+
+        await Verifier.VerifyAnalyzerAsync(test, expectedRedundant);
+    }
+
+    [Fact]
+    public async Task DeclaringExceptionWithSpecific_TreatAsCatchRest_ShouldNotReportDiagnostics()
+    {
+        var test = /* lang=c#-test */ """
+            using System;
+
+            public class TestClass
+            {
+                [Throws(typeof(InvalidOperationException), typeof(Exception))]
+                public void TestMethod()
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(test, t =>
+        {
+            t.TestState.AdditionalFiles.Add(("CheckedExceptions.settings.json", """
+            {
+                "ignoredExceptions": [],
+                "informationalExceptions": {},
+                "treatThrowsExceptionAsCatchRest": true
+            }
+            """));
+        });
+    }
+}

--- a/CheckedExceptions/AnalyzerSettings.cs
+++ b/CheckedExceptions/AnalyzerSettings.cs
@@ -58,6 +58,12 @@ public partial class AnalyzerSettings
     [JsonIgnore]
     internal bool BaseExceptionThrownDiagnosticEnabled => !DisableBaseExceptionThrownDiagnostic;
 
+    [JsonPropertyName("treatThrowsExceptionAsCatchRest")]
+    public bool TreatThrowsExceptionAsCatchRest { get; set; } = false;
+
+    [JsonIgnore]
+    internal bool TreatThrowsExceptionAsCatchRestEnabled => TreatThrowsExceptionAsCatchRest;
+
     [JsonPropertyName("ignoredExceptions")]
     public IEnumerable<string> IgnoredExceptions { get; set; } = new List<string>();
 

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.DeclaredSuperClassDetection.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.DeclaredSuperClassDetection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,7 @@ partial class CheckedExceptionsAnalyzer
         ThrowsContext context)
     {
         var semanticModel = context.SemanticModel;
+        var settings = GetAnalyzerSettings(context.Options);
         var declaredTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var typeToExprMap = new Dictionary<INamedTypeSymbol, TypeOfExpressionSyntax>(SymbolEqualityComparer.Default);
 
@@ -30,6 +32,18 @@ partial class CheckedExceptionsAnalyzer
 
                     declaredTypes.Add(exceptionType);
                     typeToExprMap[exceptionType] = typeOfExpr;
+                }
+            }
+        }
+
+        if (settings.TreatThrowsExceptionAsCatchRestEnabled)
+        {
+            foreach (var type in declaredTypes.ToArray())
+            {
+                if (type.Name == "Exception" && type.ContainingNamespace?.ToDisplayString() == "System")
+                {
+                    declaredTypes.Remove(type);
+                    typeToExprMap.Remove(type);
                 }
             }
         }

--- a/CheckedExceptions/CheckedExceptionsAnalyzer.GeneralThrows.cs
+++ b/CheckedExceptions/CheckedExceptionsAnalyzer.GeneralThrows.cs
@@ -34,6 +34,7 @@ partial class CheckedExceptionsAnalyzer
                         continue;
 
                     if (settings.BaseExceptionDeclaredDiagnosticEnabled &&
+                        !settings.TreatThrowsExceptionAsCatchRestEnabled &&
                         type.Name == generalExceptionName &&
                         type.ContainingNamespace?.ToDisplayString() == generalExceptionNamespace)
                     {

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Add `CheckedExceptions.settings.json`:
   // If true, basic redundancy checks are available when control flow analysis is disabled (default: false).
   "enableLegacyRedundancyChecks": false,
 
+  // If true, declaring [Throws(typeof(Exception))] acts as a catch-all and suppresses redundancy checks (default: false).
+  "treatThrowsExceptionAsCatchRest": false,
+
   // If true, the analyzer will not warn about declaring base type Exception with [Throws] (default: false).
   "disableBaseExceptionDeclaredDiagnostic": false,
 

--- a/SampleProject/CheckedExceptions.settings.json
+++ b/SampleProject/CheckedExceptions.settings.json
@@ -10,6 +10,7 @@
     "disableLinqImplicitlyDeclaredExceptions": false,
     "disableControlFlowAnalysis": false,
     "enableLegacyRedundancyChecks": false,
+    "treatThrowsExceptionAsCatchRest": false,
     "disableBaseExceptionDeclaredDiagnostic": false,
     "disableBaseExceptionThrownDiagnostic": false
 }

--- a/Test/CheckedExceptions.settings.json
+++ b/Test/CheckedExceptions.settings.json
@@ -10,6 +10,7 @@
     "disableLinqImplicitlyDeclaredExceptions": false,
     "disableControlFlowAnalysis": false,
     "enableLegacyRedundancyChecks": false,
+    "treatThrowsExceptionAsCatchRest": false,
     "disableBaseExceptionDeclaredDiagnostic": false,
     "disableBaseExceptionThrownDiagnostic": false
 }

--- a/docs/analyzer-specification.md
+++ b/docs/analyzer-specification.md
@@ -191,6 +191,7 @@ Control flow analysis is also used to determine whether declarations are truly n
 * **Duplicate declarations** → **`THROW005`**
 
 * **Already covered by base type** → **`THROW008`**
+  (suppressed when `treatThrowsExceptionAsCatchRest` is enabled and the base type is `System.Exception`)
 
 ### Invalid placement (Core analysis)
 
@@ -202,6 +203,7 @@ Control flow analysis is also used to determine whether declarations are truly n
 
 * **Throwing `System.Exception` directly** → **`THROW004`**
 * **Declaring `[Throws(typeof(Exception))]`** → **`THROW003`**
+  (suppressed when `treatThrowsExceptionAsCatchRest` is enabled)
 
 ---
 
@@ -469,6 +471,17 @@ These options control whether to warn about the usage of base type `Exception`.
 ```
 
 > If another analyzer is used, it might warn about the use of base type `Exceptions` instead.
+
+
+### Treat `[Throws(typeof(Exception))]` as catch-all
+
+Allows `[Throws(typeof(Exception))]` to act as a catch-all for undeclared exceptions and suppresses diagnostics `THROW003` and `THROW008`.
+
+```json
+{
+    "treatThrowsExceptionAsCatchRest": true
+}
+```
 
 
 ### Disable LINQ support

--- a/schemas/settings-schema.json
+++ b/schemas/settings-schema.json
@@ -42,6 +42,11 @@
       "default": false,
       "description": "Indicates whether the analyzer should not warn when throwing base type 'Exception'."
     },
+    "treatThrowsExceptionAsCatchRest": {
+      "type": "boolean",
+      "default": false,
+      "description": "Treat [Throws(typeof(Exception))] as a catch-all for remaining exceptions."
+    },
     "ignoredExceptions": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Summary
- add `treatThrowsExceptionAsCatchRest` setting to let `[Throws(typeof(Exception))]` act as a catch-all
- skip base-type and redundancy diagnostics when enabled
- document new option and extend schema and samples

## Testing
- `dotnet build CheckedExceptions.sln`
- `dotnet test CheckedExceptions.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b583984144832fb54a3a9ddc2f0a96