### PR TITLE
docs: document test scenario for treatThrowsExceptionAsCatchRest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - PR [#301](https://github.com/marinasundstrom/CheckedExceptions/pull/301) Allow treating `Exception` in `[Throws]` as a catch-all via `treatThrowsExceptionAsCatchRest` setting (base-type diagnostic unchanged)
+- PR [#PR_NUMBER](https://github.com/marinasundstrom/CheckedExceptions/pull/PR_NUMBER) Document test-case scenario for `treatThrowsExceptionAsCatchRest` in analyzer specification
 
 ## [2.2.3] - 2025-08-24
 

--- a/docs/analyzer-specification.md
+++ b/docs/analyzer-specification.md
@@ -482,6 +482,23 @@ Allows `[Throws(typeof(Exception))]` to act as a catch-all for undeclared except
 }
 ```
 
+This can be handy in unit tests where only assertion failures are relevant. Setup code might throw additional exceptions that you do not want to enumerate individually. Declaring `Exception` covers those extra cases while still allowing specific assertion exceptions to be declared:
+
+```csharp
+[Fact]
+[Throws(typeof(NotNullException), typeof(Exception))]
+public void Test()
+{
+    // Might throw 'FormatException' and 'OverflowException'
+    var number = int.Parse("42");
+
+    // Might throw 'NotNullException'
+    Assert.NotNull(null);
+}
+```
+
+With `treatThrowsExceptionAsCatchRest` enabled, `[Throws(typeof(Exception))]` suppresses diagnostics for the uninteresting `FormatException` and `OverflowException`, while the `NotNullException` declaration keeps the focus on assertion-related failures.
+
 
 ### Disable LINQ support
 


### PR DESCRIPTION
## Summary
- illustrate using `treatThrowsExceptionAsCatchRest` for unit tests where only assertion exceptions matter

## Testing
- `dotnet format CheckedExceptions.sln --no-restore --include CHANGELOG.md,docs/analyzer-specification.md`
- `dotnet build CheckedExceptions.sln`
- `dotnet test CheckedExceptions.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b58e92415c832f8357a487973a3f77